### PR TITLE
fix: UX audit quick wins — nav dot, contrast, search icon

### DIFF
--- a/app/board/page.tsx
+++ b/app/board/page.tsx
@@ -28,7 +28,7 @@ function getStatusColor(status: string) {
 }
 
 const priorityColors: Record<string, string> = {
-  p0: "#ef4444", p1: "#f97316", p2: "#555",
+  p0: "#ef4444", p1: "#f97316", p2: "#777",
 };
 
 const agentColors: Record<string, string> = {
@@ -199,7 +199,7 @@ export default async function BoardPage({ searchParams }: PageProps) {
                     {/* Cards */}
                     <div className="space-y-2">
                       {items.length === 0 ? (
-                        <div className="text-[10px] text-[#777] py-4 text-center border border-dashed border-[#2a2a2a] rounded-lg">
+                        <div className="text-[10px] text-[#777] py-4 text-center border border-dashed border-[#333] rounded-lg">
                           Empty
                         </div>
                       ) : (

--- a/app/products/page.tsx
+++ b/app/products/page.tsx
@@ -198,7 +198,7 @@ export default async function ProductsPage() {
                           const inner = (
                             <>
                               {idea.number && (
-                                <span className="text-[10px] text-[#2a2a2a] shrink-0 mt-0.5 font-mono">#{idea.number}</span>
+                                <span className="text-[10px] text-[#555] shrink-0 mt-0.5 font-mono">#{idea.number}</span>
                               )}
                               <span className="text-xs text-[#888] group-hover:text-[#999] transition-colors leading-relaxed flex-1">
                                 {idea.title}

--- a/components/LiveSessions.tsx
+++ b/components/LiveSessions.tsx
@@ -70,7 +70,7 @@ export function LiveSessions() {
                   {s.flags.map(f => (
                     <span key={f} className="text-[10px] text-[#777] bg-[#1a1a1a] px-1 py-0.5 rounded">{f}</span>
                   ))}
-                  <span className="text-[10px] text-[#2e2e2e]">PID {s.pid}</span>
+                  <span className="text-[10px] text-[#3a3a3a]">PID {s.pid}</span>
                 </div>
               </div>
 

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,4 +1,3 @@
-import { Search } from "lucide-react";
 import { SidebarNav, SidebarFooter, SidebarSectionLabel } from "./SidebarNav";
 import { SidebarAgentList } from "./SidebarAgentList";
 import { SidebarProjects } from "./SidebarProjects";
@@ -29,12 +28,9 @@ export function Sidebar({ projects = [] }: SidebarProps) {
       className="hidden md:flex flex-col h-screen sticky top-0 overflow-y-auto">
 
       {/* Logo */}
-      <div className="flex items-center justify-between px-4 py-4 border-b border-[#2a2a2a]">
-        <div className="flex items-center gap-2">
-          <div className="w-7 h-7 rounded bg-[#2a2a2a] flex items-center justify-center text-xs font-bold text-white">W</div>
-          <span className="font-semibold text-[#e8e8e8] text-sm">Whitebox</span>
-        </div>
-        <Search size={14} className="text-[#888]" />
+      <div className="flex items-center px-4 py-4 border-b border-[#2a2a2a] gap-2">
+        <div className="w-7 h-7 rounded bg-[#2a2a2a] flex items-center justify-center text-xs font-bold text-white">W</div>
+        <span className="font-semibold text-[#e8e8e8] text-sm">Whitebox</span>
       </div>
 
       {/* Nav links (client — reads language context) */}

--- a/components/SidebarNav.tsx
+++ b/components/SidebarNav.tsx
@@ -4,7 +4,11 @@ import { LayoutDashboard, Package, ScrollText, CircleDot, Info, CalendarClock, K
 import { usePathname } from "next/navigation";
 import { useLanguage } from "@/contexts/LanguageContext";
 
-export function SidebarNav() {
+interface SidebarNavProps {
+  onNavItemClick?: () => void;
+}
+
+export function SidebarNav({ onNavItemClick }: SidebarNavProps = {}) {
   const { t } = useLanguage();
   const pathname = usePathname();
 
@@ -30,7 +34,7 @@ export function SidebarNav() {
       {navItems.map(({ href, icon: Icon, key }) => {
         const active = isActive(href);
         return (
-          <a key={href} href={href}
+          <a key={href} href={href} onClick={onNavItemClick}
             className={`w-full flex items-center gap-2.5 px-2 py-1.5 rounded text-xs transition-colors ${
               active
                 ? "bg-[#242424] text-[#e8e8e8]"
@@ -38,7 +42,7 @@ export function SidebarNav() {
             }`}>
             <Icon size={13} className={active ? "text-[#888]" : ""} />
             <span className="flex-1">{t(key)}</span>
-            {active && <span className="w-1 h-1 rounded-full bg-[#555] shrink-0" />}
+            {active && <span className="w-1.5 h-1.5 rounded-full bg-[#e8e8e8] shrink-0" />}
           </a>
         );
       })}


### PR DESCRIPTION
## Summary
- Active nav indicator dot changed from `#555` (invisible) to `#e8e8e8` (clearly visible)
- Non-functional search icon removed from sidebar header
- Ideas pipeline issue numbers fixed: `#2a2a2a` → `#555`
- LiveSessions PID label: `#2e2e2e` → `#3a3a3a`
- Board empty column border: `#2a2a2a` → `#333`; p2 priority: `#555` → `#777`

Closes #31

## Test plan
- [ ] Navigate between pages and verify active nav item has a visible white dot
- [ ] Check sidebar header — search icon gone, logo + name only
- [ ] Products page — idea card numbers (#N) are now legible
- [ ] Board page — empty columns show visible dashed border

🤖 Generated with [Claude Code](https://claude.com/claude-code)