### PR TITLE
perf: add in-memory TTL cache to all API routes

### DIFF
--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -4,6 +4,7 @@ import path from "path";
 import { execSync } from "child_process";
 import { NextResponse } from "next/server";
 import type { McpServer, InstalledPlugin } from "@/lib/mcp-types";
+import { withCache } from "@/lib/cache";
 
 export const dynamic = "force-dynamic";
 
@@ -81,14 +82,22 @@ function readPlugins(): InstalledPlugin[] {
 }
 
 export async function GET() {
-  const globalServers = readMcpServers(path.join(HOME, ".claude.json"), "global");
-  const projectServers = readMcpServers(path.join(HOME, ".claude/mcp.json"), "project");
+  const data = await withCache<{ servers: McpServer[]; plugins: InstalledPlugin[]; updatedAt: string }>(
+    "mcp",
+    30000,
+    async () => {
+      const globalServers = readMcpServers(path.join(HOME, ".claude.json"), "global");
+      const projectServers = readMcpServers(path.join(HOME, ".claude/mcp.json"), "project");
 
-  const all = [...globalServers, ...projectServers];
-  const ps = getRunningProcesses();
+      const all = [...globalServers, ...projectServers];
+      const ps = getRunningProcesses();
 
-  const servers = all.map(s => ({ ...s, running: isRunning(s, ps) }));
-  const plugins = readPlugins();
+      const servers = all.map(s => ({ ...s, running: isRunning(s, ps) }));
+      const plugins = readPlugins();
 
-  return NextResponse.json({ servers, plugins, updatedAt: new Date().toISOString() });
+      return { servers, plugins, updatedAt: new Date().toISOString() };
+    }
+  );
+
+  return NextResponse.json(data);
 }

--- a/app/api/quota/route.ts
+++ b/app/api/quota/route.ts
@@ -2,6 +2,7 @@ import fs from "fs";
 import os from "os";
 import { execSync } from "child_process";
 import { NextResponse } from "next/server";
+import { withCache } from "@/lib/cache";
 
 export const dynamic = "force-dynamic";
 
@@ -94,28 +95,32 @@ function readLegacyCache(): QuotaResponse | null {
 }
 
 export async function GET() {
-  // On Vercel, local file reads and macOS keychain are unavailable
-  if (process.env.VERCEL) {
-    return NextResponse.json({
+  const data = await withCache<QuotaResponse>("quota", 60000, async () => {
+    // On Vercel, local file reads and macOS keychain are unavailable
+    if (process.env.VERCEL) {
+      return {
+        fiveHourPct: null, sevenDayPct: null, sevenDaySonnetPct: null,
+        fiveHourResetsAt: null, sevenDayResetsAt: null, updatedAt: null, source: "none",
+      } satisfies QuotaResponse;
+    }
+
+    // 1. Statusline cache — use it if it exists at any age (freshness shown in UI)
+    const statusline = readStatuslineCache();
+    if (statusline) return statusline;
+
+    // 2. Legacy usage-cache.json (written by capture.sh hook)
+    const legacy = readLegacyCache();
+    if (legacy) return legacy;
+
+    // 3. Last resort: live fetch from Anthropic API (slow if token expired)
+    const live = await fetchLive();
+    if (live) return live;
+
+    return {
       fiveHourPct: null, sevenDayPct: null, sevenDaySonnetPct: null,
       fiveHourResetsAt: null, sevenDayResetsAt: null, updatedAt: null, source: "none",
-    } satisfies QuotaResponse);
-  }
+    } satisfies QuotaResponse;
+  });
 
-  // 1. Statusline cache — use it if it exists at any age (freshness shown in UI)
-  const statusline = readStatuslineCache();
-  if (statusline) return NextResponse.json(statusline);
-
-  // 2. Legacy usage-cache.json (written by capture.sh hook)
-  const legacy = readLegacyCache();
-  if (legacy) return NextResponse.json(legacy);
-
-  // 3. Last resort: live fetch from Anthropic API (slow if token expired)
-  const live = await fetchLive();
-  if (live) return NextResponse.json(live);
-
-  return NextResponse.json({
-    fiveHourPct: null, sevenDayPct: null, sevenDaySonnetPct: null,
-    fiveHourResetsAt: null, sevenDayResetsAt: null, updatedAt: null, source: "none",
-  } satisfies QuotaResponse);
+  return NextResponse.json(data);
 }

--- a/app/api/schedule/route.ts
+++ b/app/api/schedule/route.ts
@@ -3,6 +3,7 @@ import fs from "fs";
 import path from "path";
 import os from "os";
 import { NextResponse } from "next/server";
+import { withCache } from "@/lib/cache";
 
 export const dynamic = "force-dynamic";
 
@@ -66,7 +67,15 @@ function getLoopRuns(limit = 50): LoopRun[] {
 }
 
 export async function GET() {
-  const cronJobs = getCronJobs();
-  const loopRuns = getLoopRuns();
-  return NextResponse.json({ cronJobs, loopRuns, updatedAt: new Date().toISOString() });
+  const data = await withCache<{ cronJobs: CronJob[]; loopRuns: LoopRun[]; updatedAt: string }>(
+    "schedule",
+    60000,
+    async () => {
+      const cronJobs = getCronJobs();
+      const loopRuns = getLoopRuns();
+      return { cronJobs, loopRuns, updatedAt: new Date().toISOString() };
+    }
+  );
+
+  return NextResponse.json(data);
 }

--- a/app/api/sessions/route.ts
+++ b/app/api/sessions/route.ts
@@ -7,6 +7,7 @@ import { NextResponse } from "next/server";
 import { Octokit } from "octokit";
 import { getProductRepos } from "@/lib/local";
 import { getAllHeartbeats } from "@/lib/redis";
+import { withCache } from "@/lib/cache";
 
 export const dynamic = "force-dynamic";
 
@@ -222,102 +223,106 @@ async function fetchGitHubActiveTasks(): Promise<ActiveTaskFile[]> {
 
 export async function GET() {
   try {
-    const { pidMap, allEntries } = buildTaskMaps();
+    const data = await withCache("sessions", 5000, async () => {
+      const { pidMap, allEntries } = buildTaskMaps();
 
-    let sessions: Session[] = [];
-    let activeTasks: ActiveTaskFile[] = [];
+      let sessions: Session[] = [];
+      let activeTasks: ActiveTaskFile[] = [];
 
-    // Try local process detection first
-    try {
-      const out = execSync("ps aux", { timeout: 3000 }).toString();
-      const lines = out.trim().split("\n").slice(1);
+      // Try local process detection first
+      try {
+        const out = execSync("ps aux", { timeout: 3000 }).toString();
+        const lines = out.trim().split("\n").slice(1);
 
-      for (const line of lines) {
-        if (!line.includes(" claude") && !line.startsWith("claude")) continue;
-        const cols = line.trim().split(/\s+/);
-        if (cols.length < 11) continue;
-        const cmdStart = cols.slice(10).join(" ");
-        if (!cmdStart.match(/^\/?.*claude(\s|$)/)) continue;
-        if (cmdStart.includes("python") || cmdStart.includes("bun") || cmdStart.includes("grep")) continue;
+        for (const line of lines) {
+          if (!line.includes(" claude") && !line.startsWith("claude")) continue;
+          const cols = line.trim().split(/\s+/);
+          if (cols.length < 11) continue;
+          const cmdStart = cols.slice(10).join(" ");
+          if (!cmdStart.match(/^\/?.*claude(\s|$)/)) continue;
+          if (cmdStart.includes("python") || cmdStart.includes("bun") || cmdStart.includes("grep")) continue;
 
-        const pid = parseInt(cols[1]);
-        const cpu = parseFloat(cols[2]);
-        const mem = parseFloat(cols[3]);
-        const started = cols[8];
-        const elapsed = cols[9];
+          const pid = parseInt(cols[1]);
+          const cpu = parseFloat(cols[2]);
+          const mem = parseFloat(cols[3]);
+          const started = cols[8];
+          const elapsed = cols[9];
 
-        const resumeMatch = cmdStart.match(/--resume\s+([a-f0-9-]{36})/);
-        const sessionId = resumeMatch?.[1] ?? null;
+          const resumeMatch = cmdStart.match(/--resume\s+([a-f0-9-]{36})/);
+          const sessionId = resumeMatch?.[1] ?? null;
 
-        const flags: string[] = [];
-        if (cmdStart.includes("--dangerously-skip-permissions")) flags.push("skip-permissions");
-        if (cmdStart.includes("--channels")) flags.push("telegram");
-        if (sessionId) flags.push("resumed");
+          const flags: string[] = [];
+          if (cmdStart.includes("--dangerously-skip-permissions")) flags.push("skip-permissions");
+          if (cmdStart.includes("--channels")) flags.push("telegram");
+          if (sessionId) flags.push("resumed");
 
-        // 1. Try PID-based join (new format)
-        const task = pidMap.get(pid) ?? null;
+          // 1. Try PID-based join (new format)
+          const task = pidMap.get(pid) ?? null;
 
-        // Note: lsof cwd lookup removed — all Claude processes report home dir,
-        // so hash matching never succeeds. activeTasks covers agent status instead.
-        const cwd: string | null = null;
+          // Note: lsof cwd lookup removed — all Claude processes report home dir,
+          // so hash matching never succeeds. activeTasks covers agent status instead.
+          const cwd: string | null = null;
 
-        const project = task?.project ?? null;
-        const label = task?.label ?? null;
-        const agentType = task?.agentType ?? null;
+          const project = task?.project ?? null;
+          const label = task?.label ?? null;
+          const agentType = task?.agentType ?? null;
 
-        let title: string;
-        let titled: boolean;
-        if (label) {
-          title = label;
-          titled = true;
-        } else {
-          if (flags.includes("telegram")) title = "Telegram Worker";
-          else if (flags.includes("skip-permissions")) title = "Autonomous Worker";
-          else if (sessionId) title = `Resumed Session · ${sessionId.slice(0, 8)}`;
-          else title = "Claude Session";
-          titled = false;
+          let title: string;
+          let titled: boolean;
+          if (label) {
+            title = label;
+            titled = true;
+          } else {
+            if (flags.includes("telegram")) title = "Telegram Worker";
+            else if (flags.includes("skip-permissions")) title = "Autonomous Worker";
+            else if (sessionId) title = `Resumed Session · ${sessionId.slice(0, 8)}`;
+            else title = "Claude Session";
+            titled = false;
+          }
+
+          sessions.push({ pid, cpu, mem, started, elapsed, sessionId, cwd, project, label, agentType, title, titled, flags });
         }
 
-        sessions.push({ pid, cpu, mem, started, elapsed, sessionId, cwd, project, label, agentType, title, titled, flags });
+        sessions.sort((a, b) => b.cpu - a.cpu);
+
+        // Active task files — recent (< 4h) task files surfaced directly for agent status
+        activeTasks = allEntries
+          .filter(e => e.ageMinutes < 240) // 4 hours
+          .map(e => ({
+            label: e.label,
+            agentType: e.agentType,
+            project: e.project,
+            updatedAt: e.updatedAt,
+            ageMinutes: Math.round(e.ageMinutes),
+          }));
+      } catch {
+        // ps aux failed (expected on Vercel)
       }
 
-      sessions.sort((a, b) => b.cpu - a.cpu);
+      // Redis heartbeat fallback: if no local sessions/tasks found, check heartbeats
+      if (sessions.length === 0 && activeTasks.length === 0) {
+        const heartbeats = await getAllHeartbeats();
+        for (const hb of heartbeats) {
+          const ageMinutes = Math.round((Date.now() - new Date(hb.lastPing).getTime()) / 60000);
+          activeTasks.push({
+            label: hb.task || `${hb.agentType} agent active`,
+            agentType: hb.agentType,
+            project: hb.project,
+            updatedAt: hb.lastPing,
+            ageMinutes,
+          });
+        }
 
-      // Active task files — recent (< 4h) task files surfaced directly for agent status
-      activeTasks = allEntries
-        .filter(e => e.ageMinutes < 240) // 4 hours
-        .map(e => ({
-          label: e.label,
-          agentType: e.agentType,
-          project: e.project,
-          updatedAt: e.updatedAt,
-          ageMinutes: Math.round(e.ageMinutes),
-        }));
-    } catch {
-      // ps aux failed (expected on Vercel)
-    }
-
-    // Redis heartbeat fallback: if no local sessions/tasks found, check heartbeats
-    if (sessions.length === 0 && activeTasks.length === 0) {
-      const heartbeats = await getAllHeartbeats();
-      for (const hb of heartbeats) {
-        const ageMinutes = Math.round((Date.now() - new Date(hb.lastPing).getTime()) / 60000);
-        activeTasks.push({
-          label: hb.task || `${hb.agentType} agent active`,
-          agentType: hb.agentType,
-          project: hb.project,
-          updatedAt: hb.lastPing,
-          ageMinutes,
-        });
+        // GitHub fallback: if Redis also empty and we're on Vercel, try GitHub events
+        if (activeTasks.length === 0 && process.env.VERCEL) {
+          activeTasks = await fetchGitHubActiveTasks();
+        }
       }
 
-      // GitHub fallback: if Redis also empty and we're on Vercel, try GitHub events
-      if (activeTasks.length === 0 && process.env.VERCEL) {
-        activeTasks = await fetchGitHubActiveTasks();
-      }
-    }
+      return { sessions, activeTasks, updatedAt: new Date().toISOString() };
+    });
 
-    return NextResponse.json({ sessions, activeTasks, updatedAt: new Date().toISOString() });
+    return NextResponse.json(data);
   } catch (err) {
     return NextResponse.json({ sessions: [], activeTasks: [], error: String(err), updatedAt: new Date().toISOString() });
   }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,7 @@ import { RefreshIndicator } from "@/components/RefreshIndicator";
 import { getDecisions, getAgentActivity, getProductRepos } from "@/lib/local";
 import { getRecentTasks } from "@/lib/github";
 
-export const revalidate = 5;
+export const revalidate = 30;
 
 export default async function Page() {
   const [decisions, activity, tasks] = await Promise.all([

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -1,0 +1,33 @@
+// Simple in-memory TTL cache for server-side route caching
+interface CacheEntry<T> {
+  value: T;
+  expiresAt: number;
+}
+
+const store = new Map<string, CacheEntry<unknown>>();
+
+export function getCached<T>(key: string): T | null {
+  const entry = store.get(key) as CacheEntry<T> | undefined;
+  if (!entry) return null;
+  if (Date.now() > entry.expiresAt) {
+    store.delete(key);
+    return null;
+  }
+  return entry.value;
+}
+
+export function setCached<T>(key: string, value: T, ttlMs: number): void {
+  store.set(key, { value, expiresAt: Date.now() + ttlMs });
+}
+
+export async function withCache<T>(
+  key: string,
+  ttlMs: number,
+  fn: () => Promise<T>
+): Promise<T> {
+  const cached = getCached<T>(key);
+  if (cached !== null) return cached;
+  const value = await fn();
+  setCached(key, value, ttlMs);
+  return value;
+}


### PR DESCRIPTION
## What
Added a server-side in-memory TTL cache utility and applied it to all four API routes to reduce redundant expensive work (process scanning, file reads, Redis/GitHub fetches) on rapid successive requests.

## Why
Closes #72

## Acceptance Criteria
- [x] `lib/cache.ts` created with `getCached`, `setCached`, and `withCache` generics
- [x] `/api/sessions` wrapped with 5s TTL cache
- [x] `/api/quota` wrapped with 60s TTL cache
- [x] `/api/mcp` wrapped with 30s TTL cache
- [x] `/api/schedule` wrapped with 60s TTL cache
- [x] `page.tsx` revalidate changed from 5 to 30
- [x] `npx tsc --noEmit` passes with zero errors
- [x] No logic changes — only caching wrappers added

## Test Plan
1. Run `npm run dev` locally
2. Open the dashboard and observe the Network tab — repeated requests to `/api/sessions`, `/api/quota`, `/api/mcp`, `/api/schedule` within their TTL windows should return instantly (no new `ps aux` / file system / Redis calls)
3. Wait for TTL to expire, confirm the next request fetches fresh data
4. Verify the page still loads and displays data correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)