### PR TITLE
feat: group sessions by agent role and show issue links

### DIFF
--- a/app/api/sessions/route.ts
+++ b/app/api/sessions/route.ts
@@ -24,6 +24,12 @@ export interface Session {
   label: string | null;
   /** Agent type from line 3 of cc-task file (e.g. "dev", "qa", "pm") */
   agentType: string | null;
+  /** GitHub issue number parsed from ISSUE= line in task file */
+  issueNumber: number | null;
+  /** GitHub repo parsed from ISSUE= line, e.g. "wkliwk/whitebox" (null if just #123 format) */
+  issueRepo: string | null;
+  /** Full GitHub URL to the issue (null if no repo context) */
+  issueUrl: string | null;
   /** Display title — label if set, otherwise auto-derived from flags */
   title: string;
   /** true if title was explicitly set by agent, false if auto-derived */
@@ -75,9 +81,44 @@ function inferAgentType(label: string): string | null {
 interface TaskEntry {
   label: string;
   agentType: string | null;
+  issueNumber: number | null;
+  issueRepo: string | null;
+  issueUrl: string | null;
   project: string;
   projectPath: string;
   updatedAt: string;
+}
+
+/** Parse an ISSUE= line from task file content lines. */
+function parseIssueLine(lines: string[]): { issueNumber: number | null; issueRepo: string | null; issueUrl: string | null } {
+  const issueLine = lines.find(l => l.startsWith("ISSUE="));
+  if (!issueLine) return { issueNumber: null, issueRepo: null, issueUrl: null };
+
+  const value = issueLine.slice("ISSUE=".length).trim();
+
+  // Format: owner/repo#123
+  const fullMatch = value.match(/^([a-zA-Z0-9_.\-]+\/[a-zA-Z0-9_.\-]+)#(\d+)$/);
+  if (fullMatch) {
+    const issueRepo = fullMatch[1];
+    const issueNumber = parseInt(fullMatch[2], 10);
+    return {
+      issueNumber,
+      issueRepo,
+      issueUrl: `https://github.com/${issueRepo}/issues/${issueNumber}`,
+    };
+  }
+
+  // Format: #123
+  const shortMatch = value.match(/^#(\d+)$/);
+  if (shortMatch) {
+    return {
+      issueNumber: parseInt(shortMatch[1], 10),
+      issueRepo: null,
+      issueUrl: null,
+    };
+  }
+
+  return { issueNumber: null, issueRepo: null, issueUrl: null };
 }
 
 function buildTaskMaps(): {
@@ -122,7 +163,9 @@ function buildTaskMaps(): {
       const explicitAgentType = lines[2] ?? null;
       const agentType = explicitAgentType || inferAgentType(label);
 
-      const entry: TaskEntry = { label, agentType, project, projectPath, updatedAt };
+      const { issueNumber, issueRepo, issueUrl } = parseIssueLine(lines);
+
+      const entry: TaskEntry = { label, agentType, issueNumber, issueRepo, issueUrl, project, projectPath, updatedAt };
 
       // New format: line 2 is PID
       const pid = parseInt(lines[1] ?? "");
@@ -266,6 +309,9 @@ export async function GET() {
           const project = task?.project ?? null;
           const label = task?.label ?? null;
           const agentType = task?.agentType ?? null;
+          const issueNumber = task?.issueNumber ?? null;
+          const issueRepo = task?.issueRepo ?? null;
+          const issueUrl = task?.issueUrl ?? null;
 
           let title: string;
           let titled: boolean;
@@ -280,7 +326,7 @@ export async function GET() {
             titled = false;
           }
 
-          sessions.push({ pid, cpu, mem, started, elapsed, sessionId, cwd, project, label, agentType, title, titled, flags });
+          sessions.push({ pid, cpu, mem, started, elapsed, sessionId, cwd, project, label, agentType, issueNumber, issueRepo, issueUrl, title, titled, flags });
         }
 
         sessions.sort((a, b) => b.cpu - a.cpu);

--- a/components/LiveSessions.tsx
+++ b/components/LiveSessions.tsx
@@ -3,6 +3,61 @@
 import { useEffect, useState } from "react";
 import type { Session } from "@/app/api/sessions/route";
 
+function SessionCard({ s }: { s: Session }) {
+  return (
+    <div className="flex items-center gap-3 py-2.5 border-b border-[#222]">
+      {/* Status dot — pulsing if titled (agent actively labeled it), static if inferred */}
+      <span className="relative flex shrink-0">
+        {s.titled && (
+          <span className="absolute inline-flex w-2 h-2 rounded-full bg-[#3b82f6] opacity-75 animate-ping" />
+        )}
+        <span className="relative inline-flex w-2 h-2 rounded-full"
+          style={{ background: s.titled ? "#3b82f6" : s.cpu > 5 ? "#3b82f6" : "#2a2a2a" }} />
+      </span>
+
+      {/* Title + meta */}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className={`text-xs font-medium truncate ${s.titled ? "text-[#e8e8e8]" : "text-[#888]"}`}>
+            {s.title}
+          </span>
+          {s.issueNumber !== null && (
+            s.issueUrl ? (
+              <a
+                href={s.issueUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[10px] text-[#5b8dee] bg-[#1a2540] px-1.5 py-0.5 rounded hover:text-[#7aa3f5] transition-colors shrink-0"
+              >
+                #{s.issueNumber}
+              </a>
+            ) : (
+              <span className="text-[10px] text-[#5b8dee] bg-[#1a2540] px-1.5 py-0.5 rounded shrink-0">
+                #{s.issueNumber}
+              </span>
+            )
+          )}
+        </div>
+        <div className="flex items-center gap-2 mt-0.5 flex-wrap">
+          {s.project && (
+            <span className="text-[10px] text-[#777]">{s.project}</span>
+          )}
+          {s.flags.map(f => (
+            <span key={f} className="text-[10px] text-[#777] bg-[#1a1a1a] px-1 py-0.5 rounded">{f}</span>
+          ))}
+          <span className="text-[10px] text-[#3a3a3a]">PID {s.pid}</span>
+        </div>
+      </div>
+
+      {/* Stats */}
+      <div className="text-right shrink-0">
+        <div className="text-[10px] text-[#777]">{s.cpu}% CPU</div>
+        <div className="text-[10px] text-[#777]">{s.elapsed}</div>
+      </div>
+    </div>
+  );
+}
+
 export function LiveSessions() {
   const [sessions, setSessions] = useState<Session[]>([]);
   const [updatedAt, setUpdatedAt] = useState<string>("");
@@ -26,6 +81,20 @@ export function LiveSessions() {
 
   const totalCpu = sessions.reduce((s, x) => s + x.cpu, 0).toFixed(1);
 
+  // Group sessions by agentType; null agentType goes into "unknown"
+  const groupMap = new Map<string, Session[]>();
+  for (const s of sessions) {
+    const key = s.agentType ?? "unknown";
+    const existing = groupMap.get(key);
+    if (existing) {
+      existing.push(s);
+    } else {
+      groupMap.set(key, [s]);
+    }
+  }
+  const groups = Array.from(groupMap.entries());
+  const showGroupHeaders = groups.length > 1;
+
   return (
     <div>
       <div className="flex items-center justify-between mb-3">
@@ -47,40 +116,23 @@ export function LiveSessions() {
         <div className="text-xs text-[#888] py-4 text-center">No active Claude sessions</div>
       ) : (
         <div className="space-y-0">
-          {sessions.map(s => (
-            <div key={s.pid} className="flex items-center gap-3 py-2.5 border-b border-[#222]">
-              {/* Status dot — pulsing if titled (agent actively labeled it), static if inferred */}
-              <span className="relative flex shrink-0">
-                {s.titled && (
-                  <span className="absolute inline-flex w-2 h-2 rounded-full bg-[#3b82f6] opacity-75 animate-ping" />
-                )}
-                <span className="relative inline-flex w-2 h-2 rounded-full"
-                  style={{ background: s.titled ? "#3b82f6" : s.cpu > 5 ? "#3b82f6" : "#2a2a2a" }} />
-              </span>
-
-              {/* Title + meta */}
-              <div className="flex-1 min-w-0">
-                <div className={`text-xs font-medium truncate ${s.titled ? "text-[#e8e8e8]" : "text-[#888]"}`}>
-                  {s.title}
+          {showGroupHeaders ? (
+            groups.map(([agentType, groupSessions]) => (
+              <div key={agentType}>
+                <div className="text-[10px] uppercase tracking-widest text-[#555] font-medium pt-3 pb-1">
+                  {agentType}
+                  <span className="ml-1 text-[#3a3a3a]">×{groupSessions.length}</span>
                 </div>
-                <div className="flex items-center gap-2 mt-0.5 flex-wrap">
-                  {s.project && (
-                    <span className="text-[10px] text-[#777]">{s.project}</span>
-                  )}
-                  {s.flags.map(f => (
-                    <span key={f} className="text-[10px] text-[#777] bg-[#1a1a1a] px-1 py-0.5 rounded">{f}</span>
-                  ))}
-                  <span className="text-[10px] text-[#3a3a3a]">PID {s.pid}</span>
-                </div>
+                {groupSessions.map(s => (
+                  <SessionCard key={s.pid} s={s} />
+                ))}
               </div>
-
-              {/* Stats */}
-              <div className="text-right shrink-0">
-                <div className="text-[10px] text-[#777]">{s.cpu}% CPU</div>
-                <div className="text-[10px] text-[#777]">{s.elapsed}</div>
-              </div>
-            </div>
-          ))}
+            ))
+          ) : (
+            sessions.map(s => (
+              <SessionCard key={s.pid} s={s} />
+            ))
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
## What
Enhances the sessions panel with two new features:
1. Each session card now displays a `#N` issue badge (parsed from an optional `ISSUE=` line in cc-task files), which is a clickable link when a full `owner/repo#N` value is present.
2. Session cards are grouped by `agentType` with a count header (e.g. `backend-dev ×2`). Grouping headers are hidden when all sessions share the same agent type.

## Why
Closes #75

## Acceptance Criteria
- [x] `ISSUE=wkliwk/repo#123` in a task file → shows clickable `#123` badge linking to GitHub
- [x] `ISSUE=#123` in a task file → shows non-linked `#123` badge (no repo context)
- [x] No `ISSUE=` line → card renders identically to before
- [x] Sessions grouped under `agentType ×N` headers when multiple agent types are active
- [x] Single-type scenario: group headers suppressed, plain list shown
- [x] `npx tsc --noEmit` passes with zero errors

## Test Plan
1. Write a task file at `/tmp/claude/cc-task-<hash>.txt` with `ISSUE=wkliwk/whitebox#75` on a new line — verify badge appears and links correctly
2. Write another with `ISSUE=#42` only — verify non-linked badge renders
3. Write one without any `ISSUE=` line — verify card unchanged
4. Spin up 2+ sessions with different `agentType` values — verify group headers appear
5. All sessions same agent type — verify no headers shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)