### PR TITLE
feat: per-agent cost breakdown on dashboard (#101)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,17 +6,19 @@ import { QuotaCard } from "@/components/QuotaCard";
 import { LiveSessions } from "@/components/LiveSessions";
 import { RefreshIndicator } from "@/components/RefreshIndicator";
 import { CostChart } from "@/components/CostChart";
-import { getDecisions, getAgentActivity, getProductRepos, getDailyActivity } from "@/lib/local";
+import { getDecisions, getAgentActivity, getProductRepos, getDailyActivity, getCostReport } from "@/lib/local";
 import { getRecentTasks } from "@/lib/github";
+import { AgentCostBreakdown } from "@/components/AgentCostBreakdown";
 
 export const revalidate = 30;
 
 export default async function Page() {
-  const [decisions, activity, tasks, dailyActivity] = await Promise.all([
+  const [decisions, activity, tasks, dailyActivity, costReport] = await Promise.all([
     getDecisions(),
     getAgentActivity(),
     getRecentTasks(),
     getDailyActivity(),
+    getCostReport(),
   ]);
 
   const repos = getProductRepos();
@@ -79,6 +81,11 @@ export default async function Page() {
               value={tasks.filter(t => t.status === "todo").length}
               subtitle={`${tasks.filter(t => t.status === "in-progress").length} in progress`}
             />
+          </div>
+
+          {/* Agent Cost Breakdown */}
+          <div className="rounded-xl border border-[#222] bg-[#161616] p-5">
+            <AgentCostBreakdown report={costReport} />
           </div>
 
           {/* Activity Chart */}

--- a/components/AgentCostBreakdown.tsx
+++ b/components/AgentCostBreakdown.tsx
@@ -1,0 +1,62 @@
+import { getAgentColor } from "@/lib/agents";
+import { formatCents } from "@/lib/utils";
+import type { CostReport } from "@/lib/costs";
+
+interface Props {
+  report: CostReport | null;
+}
+
+export function AgentCostBreakdown({ report }: Props) {
+  const header = (
+    <div className="text-[10px] uppercase tracking-widest text-[#888] font-medium mb-3">
+      Agent Cost Breakdown
+    </div>
+  );
+
+  if (!report || !report.byAgent || Object.keys(report.byAgent).length === 0) {
+    return (
+      <div>
+        {header}
+        <div className="text-xs text-[#555] py-4 text-center">No per-agent breakdown available</div>
+      </div>
+    );
+  }
+
+  const entries = Object.entries(report.byAgent)
+    .map(([agent, cents]) => ({ agent, cents: cents as number }))
+    .sort((a, b) => b.cents - a.cents);
+
+  const total = entries.reduce((sum, e) => sum + e.cents, 0);
+
+  return (
+    <div>
+      {header}
+      <div className="space-y-2.5">
+        {entries.map(({ agent, cents }) => {
+          const pct = total > 0 ? Math.round((cents / total) * 100) : 0;
+          const color = getAgentColor(agent);
+          return (
+            <div key={agent}>
+              <div className="flex items-center justify-between text-xs mb-1">
+                <div className="flex items-center gap-1.5">
+                  <div className="w-2 h-2 rounded-full flex-shrink-0" style={{ background: color }} />
+                  <span className="text-[#ccc] capitalize">{agent}</span>
+                </div>
+                <div className="flex items-center gap-2 text-[#888]">
+                  <span>{formatCents(cents)}</span>
+                  <span className="text-[#555] w-7 text-right">{pct}%</span>
+                </div>
+              </div>
+              <div className="h-1 rounded-full overflow-hidden" style={{ background: "#2a2a2a" }}>
+                <div
+                  className="h-full rounded-full"
+                  style={{ width: `${pct}%`, background: color, opacity: 0.8 }}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/lib/local.ts
+++ b/lib/local.ts
@@ -265,6 +265,33 @@ export function getRegistryProducts(): RegistryProduct[] {
   return products;
 }
 
+// ─── Cost Report ─────────────────────────────────────────────────────────────
+
+import type { CostReport } from "@/lib/costs";
+
+async function fetchCostReportFromGitHub(): Promise<CostReport | null> {
+  const octokit = await getOctokit();
+  if (!octokit) return null;
+  const owner = process.env.GITHUB_OWNER?.trim();
+  const repo = process.env.GITHUB_REPO?.trim();
+  if (!owner || !repo) return null;
+  try {
+    const { data } = await octokit.rest.repos.getContent({ owner, repo, path: "costs.json" });
+    if ("content" in data && typeof data.content === "string") {
+      return JSON.parse(Buffer.from(data.content, "base64").toString("utf-8")) as CostReport;
+    }
+    return null;
+  } catch { return null; }
+}
+
+export async function getCostReport(): Promise<CostReport | null> {
+  const raw = readFile(path.join(process.cwd(), "costs.json"));
+  if (raw) {
+    try { return JSON.parse(raw) as CostReport; } catch { return null; }
+  }
+  return fetchCostReportFromGitHub();
+}
+
 // ─── Product Repos (auto-discovered from ~/Dev/) ─────────────────────────────
 
 export interface ProductRepo {


### PR DESCRIPTION
## Summary
- Adds `AgentCostBreakdown` component with horizontal bar chart showing per-agent token spend
- Each row shows colored agent dot, name, dollar amount, percentage, and proportional bar
- Uses `AGENT_COLORS` from `lib/agents.ts` for consistent coloring
- Adds `getCostReport()` to `lib/local.ts` — reads `costs.json` locally, falls back to GitHub API for production
- Graceful empty state when `byAgent` is absent

## Test plan
- [ ] Dashboard shows "Agent Cost Breakdown" panel below metric cards
- [ ] Each agent row shows colored bar + name + amount + %
- [ ] Sorted by spend (highest first)
- [ ] Empty state renders cleanly if `byAgent` is missing
- [ ] `tsc --noEmit` passes, `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)