### PR TITLE
feat: global search/filter on Issues and Logs pages (#98)

### DIFF
--- a/app/issues/page.tsx
+++ b/app/issues/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
+import { Suspense } from "react";
 import { Sidebar } from "@/components/Sidebar";
-import { TaskList } from "@/components/TaskList";
+import { IssuesFilter } from "@/components/IssuesFilter";
 import { getProductRepos } from "@/lib/local";
 import { getRecentTasks } from "@/lib/github";
 import { PRODUCTS } from "@/lib/products";
@@ -16,9 +17,9 @@ export const revalidate = 30;
 export default async function IssuesPage({
   searchParams,
 }: {
-  searchParams: Promise<{ repo?: string }>;
+  searchParams: Promise<{ repo?: string; q?: string }>;
 }) {
-  const { repo: activeRepo } = await searchParams;
+  const { repo: activeRepo, q: initialQuery } = await searchParams;
 
   const [tasks, repos] = await Promise.all([
     getRecentTasks(),
@@ -38,12 +39,17 @@ export default async function IssuesPage({
   }
   const reposWithTasks = [...byRepo.keys()].sort();
 
-  // Apply filter
-  const filtered = activeRepo ? (byRepo.get(activeRepo) ?? []) : tasks;
+  // Apply repo filter (server-side); q filter is client-side
+  const repoFiltered = activeRepo ? (byRepo.get(activeRepo) ?? []) : tasks;
 
-  const todo = filtered.filter(t => t.status === "todo");
-  const inProgress = filtered.filter(t => t.status === "in-progress");
-  const done = filtered.filter(t => t.status === "done");
+  // Apply q filter server-side for initial stats
+  const qFiltered = initialQuery
+    ? repoFiltered.filter(t => t.title.toLowerCase().includes(initialQuery.toLowerCase()))
+    : repoFiltered;
+
+  const todo = qFiltered.filter(t => t.status === "todo");
+  const inProgress = qFiltered.filter(t => t.status === "in-progress");
+  const done = qFiltered.filter(t => t.status === "done");
 
   // Build color map from PRODUCTS
   const repoColor = new Map<string, string>();
@@ -106,8 +112,10 @@ export default async function IssuesPage({
             ))}
           </div>
 
-          {/* Filtered task list */}
-          <TaskList tasks={filtered} />
+          {/* Filtered task list with client-side search */}
+          <Suspense fallback={<div className="text-xs text-[#555] py-4">Loading…</div>}>
+            <IssuesFilter tasks={repoFiltered} initialQuery={initialQuery ?? ""} />
+          </Suspense>
         </div>
       </main>
     </div>

--- a/app/logs/page.tsx
+++ b/app/logs/page.tsx
@@ -1,7 +1,8 @@
+import { Suspense } from "react";
 import { Sidebar } from "@/components/Sidebar";
 import { ActivityFeed } from "@/components/ActivityFeed";
-import { DecisionLog } from "@/components/DecisionLog";
 import { LoopLog } from "@/components/LoopLog";
+import { DecisionFilter } from "@/components/DecisionFilter";
 import { getDecisions, getLoopLog, getProductRepos } from "@/lib/local";
 
 import type { Metadata } from "next";
@@ -12,7 +13,13 @@ export const metadata: Metadata = {
 
 export const revalidate = 10;
 
-export default async function LogsPage() {
+export default async function LogsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ q?: string }>;
+}) {
+  const { q: initialQuery } = await searchParams;
+
   const [decisions, loopLog] = await Promise.all([
     getDecisions(50),
     getLoopLog(30),
@@ -49,8 +56,10 @@ export default async function LogsPage() {
           {/* Loop Log */}
           <LoopLog entries={loopLog} />
 
-          {/* Decision Log */}
-          <DecisionLog decisions={decisions} />
+          {/* Decision Log with client-side filter */}
+          <Suspense fallback={<div className="text-xs text-[#555] py-4">Loading…</div>}>
+            <DecisionFilter decisions={decisions} initialQuery={initialQuery ?? ""} />
+          </Suspense>
         </div>
       </main>
     </div>

--- a/components/DecisionFilter.tsx
+++ b/components/DecisionFilter.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Search, X } from "lucide-react";
+import { DecisionLog } from "@/components/DecisionLog";
+import type { Decision } from "@/lib/decisions";
+
+interface Props {
+  decisions: Decision[];
+  initialQuery?: string;
+}
+
+export function DecisionFilter({ decisions, initialQuery = "" }: Props) {
+  const [query, setQuery] = useState(initialQuery);
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const filtered = query
+    ? decisions.filter(
+        d =>
+          d.summary.toLowerCase().includes(query.toLowerCase()) ||
+          d.project.toLowerCase().includes(query.toLowerCase())
+      )
+    : decisions;
+
+  const updateUrl = useCallback(
+    (q: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (q) params.set("q", q);
+      else params.delete("q");
+      router.replace(`?${params.toString()}`, { scroll: false });
+    },
+    [router, searchParams]
+  );
+
+  const handleChange = (value: string) => {
+    setQuery(value);
+    updateUrl(value);
+  };
+
+  // "/" shortcut to focus
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "/" && document.activeElement?.tagName !== "INPUT") {
+        e.preventDefault();
+        inputRef.current?.focus();
+      }
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, []);
+
+  return (
+    <div>
+      <div className="relative mb-4">
+        <Search size={13} className="absolute left-3 top-1/2 -translate-y-1/2 text-[#555] pointer-events-none" />
+        <input
+          ref={inputRef}
+          type="text"
+          placeholder="Filter decisions… (press / to focus)"
+          value={query}
+          onChange={e => handleChange(e.target.value)}
+          className="w-full text-xs pl-8 pr-8 py-2 rounded-lg border border-[#222] bg-[#1a1a1a] text-[#e8e8e8] placeholder-[#555] outline-none focus:border-[#444] transition-colors"
+        />
+        {query && (
+          <button
+            onClick={() => handleChange("")}
+            className="absolute right-2.5 top-1/2 -translate-y-1/2 text-[#555] hover:text-[#888] transition-colors"
+          >
+            <X size={13} />
+          </button>
+        )}
+      </div>
+      {filtered.length === 0 && query ? (
+        <div className="text-xs text-[#555] py-8 text-center">No decisions match &ldquo;{query}&rdquo;</div>
+      ) : (
+        <DecisionLog decisions={filtered} />
+      )}
+    </div>
+  );
+}

--- a/components/IssuesFilter.tsx
+++ b/components/IssuesFilter.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Search, X } from "lucide-react";
+import { TaskList } from "@/components/TaskList";
+import type { RecentTask } from "@/lib/github";
+
+interface Props {
+  tasks: RecentTask[];
+  initialQuery?: string;
+}
+
+export function IssuesFilter({ tasks, initialQuery = "" }: Props) {
+  const [query, setQuery] = useState(initialQuery);
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const filtered = query
+    ? tasks.filter(t => t.title.toLowerCase().includes(query.toLowerCase()))
+    : tasks;
+
+  const updateUrl = useCallback(
+    (q: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (q) params.set("q", q);
+      else params.delete("q");
+      router.replace(`?${params.toString()}`, { scroll: false });
+    },
+    [router, searchParams]
+  );
+
+  const handleChange = (value: string) => {
+    setQuery(value);
+    updateUrl(value);
+  };
+
+  // "/" shortcut to focus
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "/" && document.activeElement?.tagName !== "INPUT") {
+        e.preventDefault();
+        inputRef.current?.focus();
+      }
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, []);
+
+  return (
+    <div>
+      <div className="relative mb-6">
+        <Search size={13} className="absolute left-3 top-1/2 -translate-y-1/2 text-[#555] pointer-events-none" />
+        <input
+          ref={inputRef}
+          type="text"
+          placeholder="Filter issues… (press / to focus)"
+          value={query}
+          onChange={e => handleChange(e.target.value)}
+          className="w-full text-xs pl-8 pr-8 py-2 rounded-lg border border-[#222] bg-[#1a1a1a] text-[#e8e8e8] placeholder-[#555] outline-none focus:border-[#444] transition-colors"
+        />
+        {query && (
+          <button
+            onClick={() => handleChange("")}
+            className="absolute right-2.5 top-1/2 -translate-y-1/2 text-[#555] hover:text-[#888] transition-colors"
+          >
+            <X size={13} />
+          </button>
+        )}
+      </div>
+      {filtered.length === 0 && query ? (
+        <div className="text-xs text-[#555] py-8 text-center">No issues match &ldquo;{query}&rdquo;</div>
+      ) : (
+        <TaskList tasks={filtered} />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- `IssuesFilter` client component — search input filters issue list by title in real time; syncs to `?q=` URL param
- `DecisionFilter` client component — search input filters decision log by summary or project name; syncs to `?q=`
- Both components: clear button (×), `"/"` keyboard shortcut to focus, graceful empty state
- Issues page reads `?q=` server-side for initial stats + shareable URLs; client handles real-time updates
- Logs page wraps DecisionLog with DecisionFilter; passes `?q=` as initialQuery

## Test plan
- [ ] `/issues` — search box appears, typing filters list instantly
- [ ] Filter state in URL: navigate to `/issues?q=auth` shows filtered results
- [ ] Press `/` focuses the input from anywhere on the page
- [ ] Click × clears filter, full list restores
- [ ] `/logs` Decision Log section has its own filter input
- [ ] `tsc --noEmit` zero errors, `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)