### PR TITLE
feat: Live Sessions polls every 15s with pulse indicator and error badge (#117)

### DIFF
--- a/components/LiveSessions.tsx
+++ b/components/LiveSessions.tsx
@@ -1,46 +1,97 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { Session, ActiveTaskFile } from "@/app/api/sessions/route";
 
 export function LiveSessions() {
   const [sessions, setSessions] = useState<Session[]>([]);
   const [activeTasks, setActiveTasks] = useState<ActiveTaskFile[]>([]);
-  const [updatedAt, setUpdatedAt] = useState<string>("");
   const [loading, setLoading] = useState(true);
+  const [refreshError, setRefreshError] = useState(false);
+  const [secondsSince, setSecondsSince] = useState(0);
+  const lastFetchedAt = useRef<number>(0);
+  const pollingActive = useRef(true);
 
   async function refresh() {
+    if (!pollingActive.current) return;
     try {
       const res = await fetch("/api/sessions", { cache: "no-store" });
+      if (!res.ok) throw new Error("non-2xx");
       const data = await res.json();
       setSessions(data.sessions ?? []);
       setActiveTasks(data.activeTasks ?? []);
-      setUpdatedAt(data.updatedAt ?? "");
-    } catch { /* silent */ }
+      setRefreshError(false);
+      lastFetchedAt.current = Date.now();
+      setSecondsSince(0);
+    } catch {
+      setRefreshError(true);
+    }
     setLoading(false);
   }
 
+  // Polling: 15s interval, pauses on tab blur
   useEffect(() => {
     refresh();
-    const id = setInterval(refresh, 30000);
-    return () => clearInterval(id);
+    const pollId = setInterval(refresh, 15000);
+
+    const onVisibility = () => {
+      if (document.hidden) {
+        pollingActive.current = false;
+      } else {
+        pollingActive.current = true;
+        refresh(); // immediate refresh on tab focus
+      }
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+
+    return () => {
+      clearInterval(pollId);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // "Updated Xs ago" counter — ticks every second
+  useEffect(() => {
+    const tickId = setInterval(() => {
+      if (lastFetchedAt.current > 0) {
+        setSecondsSince(Math.floor((Date.now() - lastFetchedAt.current) / 1000));
+      }
+    }, 1000);
+    return () => clearInterval(tickId);
   }, []);
 
   const totalCpu = sessions.reduce((s, x) => s + x.cpu, 0).toFixed(1);
+  const agoLabel = secondsSince < 5 ? "just now" : `${secondsSince}s ago`;
 
   return (
     <div>
       <div className="flex items-center justify-between mb-3">
-        <div className="text-[10px] uppercase tracking-widest text-[#888] font-medium">
-          Live Sessions
+        <div className="flex items-center gap-2">
+          <div className="text-[10px] uppercase tracking-widest text-[#888] font-medium">
+            Live Sessions
+          </div>
           {sessions.length > 0 && (
-            <span className="ml-2 inline-flex items-center gap-1 text-[10px] bg-[#3b82f622] text-[#3b82f6] px-1.5 py-0.5 rounded-full font-medium">
+            <span className="inline-flex items-center gap-1 text-[10px] bg-[#3b82f622] text-[#3b82f6] px-1.5 py-0.5 rounded-full font-medium">
               <span className="w-1.5 h-1.5 rounded-full bg-[#3b82f6] inline-block animate-pulse" />
               {sessions.length} active · {totalCpu}% CPU
             </span>
           )}
+          {/* Polling pulse indicator */}
+          <span className="inline-flex items-center gap-1 text-[10px] text-[#444]">
+            <span className="w-1.5 h-1.5 rounded-full bg-[#22c55e] inline-block animate-pulse" />
+          </span>
         </div>
-        {updatedAt && <span className="text-[10px] text-[#777]">live</span>}
+        <div className="flex items-center gap-2">
+          {refreshError && (
+            <span className="text-[9px] px-1.5 py-0.5 rounded bg-[#eab30818] text-[#eab308]">
+              Refresh failed
+            </span>
+          )}
+          {!loading && lastFetchedAt.current > 0 && (
+            <span className="text-[10px] text-[#555]">Updated {agoLabel}</span>
+          )}
+        </div>
       </div>
 
       {loading ? (


### PR DESCRIPTION
## Summary
- Poll interval: 30s → 15s
- Green pulse dot in header while polling is active
- "Updated Xs ago" label ticks every second via separate interval
- Error handling: on fetch failure, retain stale data and show yellow "Refresh failed" badge (no blank panel)
- `visibilitychange` listener: pauses polling on tab blur, resumes + immediate refresh on tab focus

## Test plan
- [ ] Header shows green pulse dot at all times
- [ ] "Updated Xs ago" updates every second
- [ ] On tab switch away and back, data refreshes immediately
- [ ] Simulate fetch failure (offline) → yellow badge appears, data stays
- [ ] `tsc --noEmit` zero errors, `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)