### PR TITLE
feat: loop log pagination + Redis cap 200 (#119)

### DIFF
--- a/app/api/loop-events/route.ts
+++ b/app/api/loop-events/route.ts
@@ -1,11 +1,15 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { getLoopEvents } from "@/lib/redis";
 
-export const revalidate = 10;
+export const dynamic = "force-dynamic";
 
-export async function GET() {
-  const events = await getLoopEvents(30);
-  return NextResponse.json(events, {
+export async function GET(req: NextRequest) {
+  const { searchParams } = req.nextUrl;
+  const offset = Math.max(0, parseInt(searchParams.get("offset") ?? "0", 10) || 0);
+  const limit = Math.min(100, Math.max(1, parseInt(searchParams.get("limit") ?? "50", 10) || 50));
+
+  const result = await getLoopEvents(limit, offset);
+  return NextResponse.json(result, {
     headers: { "Cache-Control": "public, s-maxage=10, stale-while-revalidate=5" },
   });
 }

--- a/app/logs/page.tsx
+++ b/app/logs/page.tsx
@@ -20,10 +20,11 @@ export default async function LogsPage({
 }) {
   const { q: initialQuery } = await searchParams;
 
-  const [decisions, loopLog] = await Promise.all([
+  const [decisions, loopLogResult] = await Promise.all([
     getDecisions(50),
-    getLoopLog(30),
+    getLoopLog(50),
   ]);
+  const { entries: loopEntries, total: loopTotal, totalErrors: loopErrors } = loopLogResult;
 
   const activityEvents = decisions.slice(0, 20).map(d => ({
     agent: d.project,
@@ -54,7 +55,7 @@ export default async function LogsPage({
           <ActivityFeed events={activityEvents} />
 
           {/* Loop Log */}
-          <LoopLog entries={loopLog} />
+          <LoopLog entries={loopEntries} total={loopTotal} totalErrors={loopErrors} />
 
           {/* Decision Log with client-side filter */}
           <Suspense fallback={<div className="text-xs text-[#555] py-4">Loading…</div>}>

--- a/components/LoopLog.tsx
+++ b/components/LoopLog.tsx
@@ -1,4 +1,9 @@
+"use client";
+
+import { useEffect, useState } from "react";
 import type { LogEntry } from "@/lib/local";
+
+const PAGE_SIZE = 50;
 
 const LEVEL_STYLES: Record<LogEntry["level"], { border: string; label: string; text: string }> = {
   error: { border: "#ef4444", label: "#ef4444", text: "#fca5a5" },
@@ -7,42 +12,136 @@ const LEVEL_STYLES: Record<LogEntry["level"], { border: string; label: string; t
   debug: { border: "#444",    label: "#555",    text: "#888"    },
 };
 
-export function LoopLog({ entries }: { entries: LogEntry[] }) {
-  const errorCount = entries.filter(e => e.level === "error").length;
+interface Props {
+  /** Server-rendered initial entries (dev: from local file; production: first page from Redis) */
+  entries: LogEntry[];
+  /** Total count across all stored events */
+  total?: number;
+  /** Total error count across all stored events */
+  totalErrors?: number;
+}
+
+export function LoopLog({ entries: initialEntries, total: initialTotal, totalErrors: initialTotalErrors }: Props) {
+  const [entries, setEntries] = useState<LogEntry[]>(initialEntries);
+  const [total, setTotal] = useState(initialTotal ?? initialEntries.length);
+  const [totalErrors, setTotalErrors] = useState(
+    initialTotalErrors ?? initialEntries.filter(e => e.level === "error").length
+  );
+  const [offset, setOffset] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [isClient, setIsClient] = useState(false);
+  const [isProduction, setIsProduction] = useState(false);
+
+  useEffect(() => {
+    setIsClient(true);
+    setIsProduction(window.location.hostname !== "localhost");
+  }, []);
+
+  async function fetchPage(newOffset: number) {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/loop-events?offset=${newOffset}&limit=${PAGE_SIZE}`, { cache: "no-store" });
+      const data = await res.json();
+      setEntries(data.events ?? []);
+      setTotal(data.total ?? 0);
+      setTotalErrors(data.totalErrors ?? 0);
+      setOffset(newOffset);
+    } catch { /* retain current page */ }
+    setLoading(false);
+  }
+
+  // For local dev, slice the server-provided flat array; for production, use fetched page
+  const visibleEntries = (!isClient || !isProduction)
+    ? initialEntries.slice(offset, offset + PAGE_SIZE)
+    : entries;
+
+  const effectiveTotal = (!isClient || !isProduction) ? initialEntries.length : total;
+  const totalPages = Math.ceil(effectiveTotal / PAGE_SIZE);
+  const currentPage = Math.floor(offset / PAGE_SIZE);
+  const start = offset + 1;
+  const end = Math.min(offset + PAGE_SIZE, effectiveTotal);
+  const hasPrev = offset > 0;
+  const hasNext = end < effectiveTotal;
+
+  function handlePrev() {
+    const newOffset = offset - PAGE_SIZE;
+    if (isProduction) fetchPage(newOffset);
+    else setOffset(newOffset);
+  }
+
+  function handleNext() {
+    const newOffset = offset + PAGE_SIZE;
+    if (isProduction) fetchPage(newOffset);
+    else setOffset(newOffset);
+  }
 
   return (
     <div>
       <div className="flex items-center justify-between mb-3">
         <div className="text-[10px] uppercase tracking-widest text-[#888] font-medium">Loop Log</div>
-        {errorCount > 0 && (
-          <span className="text-[10px] font-medium px-1.5 py-0.5 rounded"
-            style={{ background: "#ef444422", color: "#ef4444" }}>
-            {errorCount} error{errorCount !== 1 ? "s" : ""}
-          </span>
-        )}
-      </div>
-      {entries.length === 0 ? (
-        <div className="text-xs text-[#888] py-4 text-center">No loop log entries yet</div>
-      ) : (
-        <div className="space-y-0">
-          {entries.map((e, i) => {
-            const s = LEVEL_STYLES[e.level];
-            return (
-              <div key={i}
-                className="flex items-start gap-3 py-2 border-b border-[#222] pl-2"
-                style={{ borderLeft: `2px solid ${s.border}` }}>
-                <span className="text-[10px] text-[#888] shrink-0 mt-0.5 w-32">{e.timestamp || "—"}</span>
-                {e.product && (
-                  <span className="text-[10px] font-medium px-1.5 py-0.5 rounded shrink-0"
-                    style={{ background: `${s.label}22`, color: s.label }}>
-                    {e.product}
-                  </span>
-                )}
-                <span className="text-xs leading-relaxed" style={{ color: s.text }}>{e.action}</span>
-              </div>
-            );
-          })}
+        <div className="flex items-center gap-2">
+          {totalErrors > 0 && (
+            <span className="text-[10px] font-medium px-1.5 py-0.5 rounded"
+              style={{ background: "#ef444422", color: "#ef4444" }}>
+              {totalErrors} error{totalErrors !== 1 ? "s" : ""}
+            </span>
+          )}
+          {effectiveTotal > PAGE_SIZE && (
+            <span className="text-[10px] text-[#555]">
+              {start}–{end} of {effectiveTotal}
+            </span>
+          )}
         </div>
+      </div>
+
+      {visibleEntries.length === 0 ? (
+        <div className="text-xs text-[#888] py-4 text-center">
+          {loading ? "Loading…" : "No loop log entries yet"}
+        </div>
+      ) : (
+        <>
+          <div className={`space-y-0 transition-opacity duration-150 ${loading ? "opacity-50" : "opacity-100"}`}>
+            {visibleEntries.map((e, i) => {
+              const s = LEVEL_STYLES[e.level];
+              return (
+                <div key={i}
+                  className="flex items-start gap-3 py-2 border-b border-[#222] pl-2"
+                  style={{ borderLeft: `2px solid ${s.border}` }}>
+                  <span className="text-[10px] text-[#888] shrink-0 mt-0.5 w-32">{e.timestamp || "—"}</span>
+                  {e.product && (
+                    <span className="text-[10px] font-medium px-1.5 py-0.5 rounded shrink-0"
+                      style={{ background: `${s.label}22`, color: s.label }}>
+                      {e.product}
+                    </span>
+                  )}
+                  <span className="text-xs leading-relaxed" style={{ color: s.text }}>{e.action}</span>
+                </div>
+              );
+            })}
+          </div>
+
+          {totalPages > 1 && (
+            <div className="flex items-center justify-between mt-3 pt-3 border-t border-[#222]">
+              <button
+                onClick={handlePrev}
+                disabled={!hasPrev || loading}
+                className="text-[11px] px-3 py-1 rounded border border-[#2a2a2a] text-[#888] hover:text-[#ccc] hover:border-[#444] disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+              >
+                ← Newer
+              </button>
+              <span className="text-[10px] text-[#555]">
+                Page {currentPage + 1} of {totalPages}
+              </span>
+              <button
+                onClick={handleNext}
+                disabled={!hasNext || loading}
+                className="text-[11px] px-3 py-1 rounded border border-[#2a2a2a] text-[#888] hover:text-[#ccc] hover:border-[#444] disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+              >
+                Older →
+              </button>
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/lib/local.ts
+++ b/lib/local.ts
@@ -120,16 +120,23 @@ function classifyLevel(action: string): LogEntry["level"] {
   return "info";
 }
 
-export async function getLoopLog(limit = 30): Promise<LogEntry[]> {
+export interface LoopLogResult {
+  entries: LogEntry[];
+  total: number;
+  totalErrors: number;
+}
+
+export async function getLoopLog(limit = 50): Promise<LoopLogResult> {
   // In production, read from Redis (pushed by local machine via push-loop-event.sh)
   if (process.env.NODE_ENV === "production") {
     const { getLoopEvents } = await import("./redis");
-    return getLoopEvents(limit);
+    const result = await getLoopEvents(limit, 0);
+    return { entries: result.events, total: result.total, totalErrors: result.totalErrors };
   }
   // Local dev: read file directly
   const raw = readFile(path.join(HOME, "Dev/whitebox/history/loop-log.txt"));
-  if (!raw) return [];
-  return raw
+  if (!raw) return { entries: [], total: 0, totalErrors: 0 };
+  const parsed = raw
     .trim()
     .split("\n")
     .filter(Boolean)
@@ -150,6 +157,7 @@ export async function getLoopLog(limit = 30): Promise<LogEntry[]> {
     })
     .slice(-limit)
     .reverse();
+  return { entries: parsed, total: parsed.length, totalErrors: parsed.filter((e: LogEntry) => e.level === "error").length };
 }
 
 // ─── Daily Activity (last 7 days, from decisions.jsonl) ──────────────────────

--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -65,20 +65,42 @@ export async function getAllHeartbeats(): Promise<Heartbeat[]> {
 
 const LOOP_EVENTS_KEY = "whitebox:loop-events";
 
-export async function getLoopEvents(limit = 30): Promise<LogEntry[]> {
-  const redis = getRedis();
-  if (!redis) return [];
+function parseLoopEvent(item: unknown): LogEntry {
   try {
-    const raw: string[] = await redis.lrange(LOOP_EVENTS_KEY, 0, limit - 1);
-    return raw.map(item => {
-      try {
-        const parsed = typeof item === "string" ? JSON.parse(item) : item;
-        return parsed as LogEntry;
-      } catch {
-        return { timestamp: "", product: "", action: String(item), level: "debug" as const };
-      }
-    });
+    const parsed = typeof item === "string" ? JSON.parse(item) : item;
+    return parsed as LogEntry;
   } catch {
-    return [];
+    return { timestamp: "", product: "", action: String(item), level: "debug" as const };
+  }
+}
+
+export interface LoopEventsResult {
+  events: LogEntry[];
+  total: number;
+  totalErrors: number;
+  offset: number;
+  limit: number;
+}
+
+export async function getLoopEvents(limit = 50, offset = 0): Promise<LoopEventsResult> {
+  const redis = getRedis();
+  if (!redis) return { events: [], total: 0, totalErrors: 0, offset, limit };
+  try {
+    const [page, allRaw, totalRaw] = await Promise.all([
+      redis.lrange(LOOP_EVENTS_KEY, offset, offset + limit - 1) as Promise<string[]>,
+      redis.lrange(LOOP_EVENTS_KEY, 0, 199) as Promise<string[]>,
+      redis.llen(LOOP_EVENTS_KEY) as Promise<number>,
+    ]);
+    const all = allRaw.map(parseLoopEvent);
+    const totalErrors = all.filter(e => e.level === "error").length;
+    return {
+      events: page.map(parseLoopEvent),
+      total: totalRaw,
+      totalErrors,
+      offset,
+      limit,
+    };
+  } catch {
+    return { events: [], total: 0, totalErrors: 0, offset, limit };
   }
 }


### PR DESCRIPTION
## Summary
- `push-loop-event.sh` LTRIM cap: 100 → 200 entries
- `/api/loop-events` now accepts `?offset=&limit=` (default limit 50, max 100), returns `{events, total, totalErrors, offset, limit}` envelope
- `LoopLog` converted to client component with 50-per-page pagination: Older/Newer buttons, "Events X–Y of Z" label, error count badge reflects ALL stored events (not just current page)
- `getLoopLog` in `lib/local.ts` returns `LoopLogResult` envelope; `getLoopEvents` in `lib/redis.ts` updated to support offset + return totalErrors
- `app/logs/page.tsx` destructures new result shape

## Test plan
- [ ] Logs page shows Loop Log with pagination controls when >50 events
- [ ] "Older" button loads next page, "Newer" loads previous
- [ ] Error count badge in header matches total errors across all events
- [ ] `tsc --noEmit` zero errors, `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)