### PR TITLE
feat: last completed task on agent cards (#120)

### DIFF
--- a/app/api/agents/route.ts
+++ b/app/api/agents/route.ts
@@ -3,17 +3,9 @@ const fs = require("fs") as typeof import("fs");
 const path = require("path") as typeof import("path");
 const os = require("os") as typeof import("os");
 import { NextResponse } from "next/server";
+import type { AgentDef } from "@/lib/agents";
 
 export const dynamic = "force-dynamic";
-
-export interface AgentDef {
-  id: string;
-  name: string;
-  description: string;
-  category: string;
-  color: string;
-  githubLabel: string;
-}
 
 const KNOWN_COLORS: Record<string, string> = {
   ceo: "#8b5cf6", pm: "#3b82f6", "frontend-dev": "#06b6d4", "backend-dev": "#0ea5e9",
@@ -51,5 +43,16 @@ function loadAgents(): AgentDef[] {
 }
 
 export async function GET() {
-  return NextResponse.json({ agents: loadAgents() });
+  const agents = loadAgents();
+  // Merge last-task data from Redis (production only — Redis not available in local dev without env vars)
+  try {
+    const { getAgentLastTasks } = await import("@/lib/redis");
+    const lastTasks = await getAgentLastTasks();
+    if (Object.keys(lastTasks).length > 0) {
+      for (const agent of agents) {
+        if (lastTasks[agent.id]) agent.lastTask = lastTasks[agent.id];
+      }
+    }
+  } catch { /* no Redis — return without lastTask */ }
+  return NextResponse.json({ agents });
 }

--- a/app/api/heartbeat/route.ts
+++ b/app/api/heartbeat/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { writeHeartbeat, removeHeartbeat, getAllHeartbeats, type Heartbeat } from "@/lib/redis";
+import { writeHeartbeat, removeHeartbeat, getAllHeartbeats, setAgentLastTask, type Heartbeat } from "@/lib/redis";
 
 export const dynamic = "force-dynamic";
 
@@ -14,11 +14,13 @@ export async function POST(req: Request) {
   }
 
   const body = await req.json();
-  const { agentType, status, task, project } = body as {
+  const { agentType, status, task, project, issueNumber, issueRepo } = body as {
     agentType?: string;
     status?: string;
     task?: string;
     project?: string;
+    issueNumber?: number;
+    issueRepo?: string;
   };
 
   if (!agentType || !status) {
@@ -26,7 +28,16 @@ export async function POST(req: Request) {
   }
 
   if (status === "completed") {
-    const ok = await removeHeartbeat(agentType);
+    const [ok] = await Promise.all([
+      removeHeartbeat(agentType),
+      setAgentLastTask(agentType, {
+        task: task ?? "",
+        project: project ?? "",
+        issueNumber: issueNumber ?? undefined,
+        issueRepo: issueRepo ?? undefined,
+        completedAt: new Date().toISOString(),
+      }),
+    ]);
     return NextResponse.json({ ok, agentType, status });
   }
 

--- a/components/OrgChart.tsx
+++ b/components/OrgChart.tsx
@@ -5,6 +5,7 @@ import { createPortal } from "react-dom";
 import { AgentDrawer } from "./AgentDrawer";
 import { useAgents } from "@/lib/useAgents";
 import { getAgentColor } from "@/lib/agents";
+import { relativeTime } from "@/lib/utils";
 import type { AgentDef } from "@/lib/agents";
 import type { Session, ActiveTaskFile } from "@/app/api/sessions/route";
 
@@ -89,11 +90,13 @@ interface NodeCardProps {
   sessions: Session[];
   activeTasks: ActiveTaskFile[];
   onOpen: (id: string, name: string) => void;
+  agentMap: Map<string, AgentDef>;
 }
 
-function NodeCard({ node, sessions, activeTasks, onOpen }: NodeCardProps) {
+function NodeCard({ node, sessions, activeTasks, onOpen, agentMap }: NodeCardProps) {
   const color = getAgentColor(node.id);
   const { live, label } = isLive(node.id, sessions, activeTasks);
+  const lastTask = agentMap.get(node.id)?.lastTask;
 
   return (
     <button
@@ -138,6 +141,27 @@ function NodeCard({ node, sessions, activeTasks, onOpen }: NodeCardProps) {
             {label}
           </div>
         )}
+        {!live && lastTask && (
+          <div className="mt-1.5 space-y-0.5">
+            <div className="text-[9px] text-[#666] max-w-[90px] truncate leading-tight">
+              {lastTask.task.length > 50 ? lastTask.task.slice(0, 50) + "…" : lastTask.task || "completed task"}
+            </div>
+            <div className="flex items-center justify-center gap-1">
+              <span className="text-[9px] text-[#444]">{relativeTime(lastTask.completedAt)}</span>
+              {lastTask.issueNumber && lastTask.issueRepo && (
+                <a
+                  href={`https://github.com/${lastTask.issueRepo}/issues/${lastTask.issueNumber}`}
+                  target="_blank"
+                  rel="noreferrer"
+                  onClick={e => e.stopPropagation()}
+                  className="text-[9px] px-1 py-0.5 rounded bg-[#2a2a2a] text-[#666] hover:text-[#999] transition-colors"
+                >
+                  #{lastTask.issueNumber}
+                </a>
+              )}
+            </div>
+          </div>
+        )}
       </div>
     </button>
   );
@@ -145,6 +169,7 @@ function NodeCard({ node, sessions, activeTasks, onOpen }: NodeCardProps) {
 
 export function OrgChart() {
   const agents = useAgents();
+  const agentMap = new Map(agents.map(a => [a.id, a]));
   const [sessions, setSessions] = useState<Session[]>([]);
   const [activeTasks, setActiveTasks] = useState<ActiveTaskFile[]>([]);
   const [openAgent, setOpenAgent] = useState<{ id: string; name: string } | null>(null);
@@ -198,7 +223,7 @@ export function OrgChart() {
       <div className={`overflow-x-auto pb-8 ${loading ? "hidden" : ""}`}>
         <div className="flex flex-col items-center min-w-max">
           {/* Root */}
-          <NodeCard node={ORG} sessions={sessions} activeTasks={activeTasks} onOpen={(id, name) => setOpenAgent({ id, name })} />
+          <NodeCard node={ORG} sessions={sessions} activeTasks={activeTasks} onOpen={(id, name) => setOpenAgent({ id, name })} agentMap={agentMap} />
 
           {/* Children tree */}
           {ORG.children && ORG.children.length > 0 && (
@@ -220,7 +245,7 @@ export function OrgChart() {
                   {ORG.children.map(child => (
                     <div key={child.id} className="flex flex-col items-center">
                       <div className="w-px h-10 bg-[#2a2a2a]" />
-                      <NodeCard node={child} sessions={sessions} activeTasks={activeTasks} onOpen={(id, name) => setOpenAgent({ id, name })} />
+                      <NodeCard node={child} sessions={sessions} activeTasks={activeTasks} onOpen={(id, name) => setOpenAgent({ id, name })} agentMap={agentMap} />
 
                       {child.children && child.children.length > 0 && (
                         <div className="flex flex-col items-center">
@@ -238,7 +263,7 @@ export function OrgChart() {
                               {child.children.map(gc => (
                                 <div key={gc.id} className="flex flex-col items-center">
                                   <div className="w-px h-10 bg-[#2a2a2a]" />
-                                  <NodeCard node={gc} sessions={sessions} activeTasks={activeTasks} onOpen={(id, name) => setOpenAgent({ id, name })} />
+                                  <NodeCard node={gc} sessions={sessions} activeTasks={activeTasks} onOpen={(id, name) => setOpenAgent({ id, name })} agentMap={agentMap} />
                                 </div>
                               ))}
                             </div>

--- a/lib/agents.ts
+++ b/lib/agents.ts
@@ -13,6 +13,14 @@ export const AGENT_COLORS: Record<string, string> = {
   "claude-code-manager": "#a855f7",
 };
 
+export interface AgentLastTask {
+  task: string;
+  project: string;
+  issueNumber?: number;
+  issueRepo?: string;
+  completedAt: string;
+}
+
 export interface AgentDef {
   id: string;
   name: string;
@@ -20,6 +28,7 @@ export interface AgentDef {
   category: string;
   color: string;
   githubLabel: string;
+  lastTask?: AgentLastTask;
 }
 
 export function getAgentColor(id: string): string {

--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -15,6 +15,45 @@ export function getRedis(): any | null {
   return _redis;
 }
 
+// ─── Last Task ───────────────────────────────────────────────────────────────
+
+export interface LastTask {
+  task: string;
+  project: string;
+  issueNumber?: number;
+  issueRepo?: string;
+  completedAt: string;
+}
+
+const LAST_TASK_PREFIX = "agent:last-task:";
+const LAST_TASK_TTL = 86400; // 24h
+
+export async function setAgentLastTask(agentType: string, record: LastTask): Promise<void> {
+  const redis = getRedis();
+  if (!redis) return;
+  try {
+    await redis.set(`${LAST_TASK_PREFIX}${agentType}`, JSON.stringify(record), { ex: LAST_TASK_TTL });
+  } catch { /* silent */ }
+}
+
+export async function getAgentLastTasks(): Promise<Record<string, LastTask>> {
+  const redis = getRedis();
+  if (!redis) return {};
+  try {
+    const keys: string[] = await redis.keys(`${LAST_TASK_PREFIX}*`);
+    if (!keys.length) return {};
+    const values: (string | null)[] = await redis.mget(...keys);
+    const result: Record<string, LastTask> = {};
+    keys.forEach((key, i) => {
+      const val = values[i];
+      if (!val) return;
+      const agentType = key.replace(LAST_TASK_PREFIX, "");
+      try { result[agentType] = JSON.parse(val) as LastTask; } catch { /* skip malformed */ }
+    });
+    return result;
+  } catch { return {}; }
+}
+
 // ─── Heartbeat Types ────────────────────────────────────────────────────────
 
 export interface Heartbeat {


### PR DESCRIPTION
## Summary
- `lib/redis.ts` — `setAgentLastTask(agentType, record)` writes `agent:last-task:<type>` with 24h TTL; `getAgentLastTasks()` reads all keys and returns `Record<string, LastTask>`
- `app/api/heartbeat/route.ts` — on `status: "completed"`, writes last-task record alongside removing heartbeat; accepts `issueNumber` + `issueRepo` from body
- `lib/agents.ts` — `AgentDef` gains optional `lastTask?: AgentLastTask` field
- `app/api/agents/route.ts` — merges last-task from Redis into agent list; removed local duplicate `AgentDef` interface (now imports from `lib/agents.ts`)
- `components/OrgChart.tsx` — `NodeCard` shows last task label (≤50 chars), relative time, `#NNN` chip linking to GitHub issue when agent is offline

## Test plan
- [ ] Complete a heartbeat (`status: completed`) → Teams page shows last task label below agent dot
- [ ] `#NNN` chip links to the correct GitHub issue
- [ ] Live agents still show current label (not last-task)
- [ ] Agents with no last-task record show nothing extra
- [ ] `tsc --noEmit` zero errors, `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)