### PR TITLE
feat: monthly spend metric card on dashboard (#118)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,4 @@
-import { Bot, CheckSquare, Activity } from "lucide-react";
+import { Bot, CheckSquare, Activity, DollarSign } from "lucide-react";
 import Link from "next/link";
 import { Sidebar } from "@/components/Sidebar";
 import { MetricCard } from "@/components/MetricCard";
@@ -9,6 +9,7 @@ import { CostChart } from "@/components/CostChart";
 import { getDecisions, getAgentActivity, getProductRepos, getDailyActivity, getCostReport } from "@/lib/local";
 import { getRecentTasks } from "@/lib/github";
 import { AgentCostBreakdown } from "@/components/AgentCostBreakdown";
+import { formatSpend, budgetPct } from "@/lib/costs";
 
 export const revalidate = 30;
 
@@ -60,7 +61,7 @@ export default async function Page() {
           <LiveSessions />
 
           {/* Metric Cards */}
-          <div className="grid grid-cols-2 xl:grid-cols-4 gap-3">
+          <div className="grid grid-cols-2 xl:grid-cols-5 gap-3">
             <QuotaCard />
             <MetricCard
               icon={Bot}
@@ -80,6 +81,12 @@ export default async function Page() {
               label="Open Tasks"
               value={tasks.filter(t => t.status === "todo").length}
               subtitle={`${tasks.filter(t => t.status === "in-progress").length} in progress`}
+            />
+            <MetricCard
+              icon={DollarSign}
+              label={costReport ? `Spend ${costReport.month}` : "Monthly Spend"}
+              value={costReport ? formatSpend(costReport.mtdSpend) : "--"}
+              subtitle={costReport ? `${budgetPct(costReport)}% of ${formatSpend(costReport.budget)} budget` : "costs.json not found"}
             />
           </div>
 

--- a/lib/costs.ts
+++ b/lib/costs.ts
@@ -7,3 +7,20 @@ export interface CostReport {
   byAgent: Record<string, number>;
   byCategory: Record<string, number>;
 }
+
+/** Sonnet 4.6 pricing in USD per million tokens */
+export const PRICING = {
+  inputPerMTok: 3.0,
+  outputPerMTok: 15.0,
+} as const;
+
+/** Format a cost in USD cents as a short dollar string (e.g. 2014 → "$20.14") */
+export function formatSpend(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+/** Compute budget utilisation percentage (0-100) */
+export function budgetPct(report: CostReport): number {
+  if (!report.budget) return 0;
+  return Math.min(100, Math.round((report.mtdSpend / report.budget) * 100));
+}


### PR DESCRIPTION
## Summary
- New 5th MetricCard showing MTD spend from `costs.json`: value = "$20.00", subtitle = "40% of $50 budget · 2026-03"
- Dashboard metric grid: `xl:grid-cols-4` → `xl:grid-cols-5`
- `lib/costs.ts` extended with `PRICING` constants (Sonnet 4.6: $3/$15 per MTok), `formatSpend()`, `budgetPct()` helpers
- Graceful: shows "--" / "costs.json not found" when data absent

## Notes
The issue asked for "today's cost" derived from token counts in usage-cache.json. The actual cache only stores utilisation percentages (not token counts), so per-session dollar attribution isn't available from that source. The `costs.json` file has accurate MTD spend tracked by the Finance agent — that's what this card shows. "Today's cost" would require either: (a) ccusage or similar per-session token logging, or (b) the Finance agent writing daily granularity to costs.json.

## Test plan
- [ ] Dashboard shows "$20.00" Monthly Spend card in the metric row
- [ ] Shows "--" when costs.json is missing (production)
- [ ] `tsc --noEmit` zero errors, `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)