### PR TITLE
feat: session history timeline (#116)

### DIFF
--- a/app/api/heartbeat/route.ts
+++ b/app/api/heartbeat/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { writeHeartbeat, removeHeartbeat, getAllHeartbeats, setAgentLastTask, type Heartbeat } from "@/lib/redis";
+import { writeHeartbeat, removeHeartbeat, getAllHeartbeats, setAgentLastTask, pushSessionHistory, type Heartbeat } from "@/lib/redis";
 
 export const dynamic = "force-dynamic";
 
@@ -14,13 +14,14 @@ export async function POST(req: Request) {
   }
 
   const body = await req.json();
-  const { agentType, status, task, project, issueNumber, issueRepo } = body as {
+  const { agentType, status, task, project, issueNumber, issueRepo, startedAt: bodyStartedAt } = body as {
     agentType?: string;
     status?: string;
     task?: string;
     project?: string;
     issueNumber?: number;
     issueRepo?: string;
+    startedAt?: string;
   };
 
   if (!agentType || !status) {
@@ -28,6 +29,9 @@ export async function POST(req: Request) {
   }
 
   if (status === "completed") {
+    const completedAt = new Date().toISOString();
+    const startedAt = bodyStartedAt ?? completedAt;
+    const durationMs = new Date(completedAt).getTime() - new Date(startedAt).getTime();
     const [ok] = await Promise.all([
       removeHeartbeat(agentType),
       setAgentLastTask(agentType, {
@@ -35,7 +39,15 @@ export async function POST(req: Request) {
         project: project ?? "",
         issueNumber: issueNumber ?? undefined,
         issueRepo: issueRepo ?? undefined,
-        completedAt: new Date().toISOString(),
+        completedAt,
+      }),
+      pushSessionHistory({
+        agentType,
+        task: task ?? "",
+        project: project ?? "",
+        startedAt,
+        completedAt,
+        durationMs,
       }),
     ]);
     return NextResponse.json({ ok, agentType, status });

--- a/app/api/sessions/route.ts
+++ b/app/api/sessions/route.ts
@@ -7,7 +7,7 @@ const os = require("os") as typeof import("os");
 import { NextResponse } from "next/server";
 // Dynamic import to avoid TDZ issues with webpack externalization
 import { getProductRepos } from "@/lib/local";
-import { getAllHeartbeats } from "@/lib/redis";
+import { getAllHeartbeats, getSessionHistory } from "@/lib/redis";
 import { withCache } from "@/lib/cache";
 
 export const dynamic = "force-dynamic";
@@ -314,7 +314,7 @@ export async function GET() {
       }
 
       // Always merge Redis heartbeats — they carry agent type info that ps aux lacks
-      const heartbeats = await getAllHeartbeats();
+      const [heartbeats, history] = await Promise.all([getAllHeartbeats(), getSessionHistory()]);
       const seenAgentTypes = new Set(activeTasks.map(t => t.agentType).filter(Boolean));
       for (const hb of heartbeats) {
         // Skip if we already have a local task file for this agent type
@@ -336,7 +336,7 @@ export async function GET() {
         activeTasks = await fetchGitHubActiveTasks();
       }
 
-      return { sessions, activeTasks, updatedAt: new Date().toISOString() };
+      return { sessions, activeTasks, history, updatedAt: new Date().toISOString() };
     });
 
     return NextResponse.json(data);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,6 +9,7 @@ import { CostChart } from "@/components/CostChart";
 import { getDecisions, getAgentActivity, getProductRepos, getDailyActivity, getCostReport } from "@/lib/local";
 import { getRecentTasks } from "@/lib/github";
 import { AgentCostBreakdown } from "@/components/AgentCostBreakdown";
+import { SessionHistory } from "@/components/SessionHistory";
 import { formatSpend, budgetPct } from "@/lib/costs";
 
 export const revalidate = 30;
@@ -59,6 +60,9 @@ export default async function Page() {
 
           {/* Live Sessions */}
           <LiveSessions />
+
+          {/* Session History */}
+          <SessionHistory />
 
           {/* Metric Cards */}
           <div className="grid grid-cols-2 xl:grid-cols-5 gap-3">

--- a/components/SessionHistory.tsx
+++ b/components/SessionHistory.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { getAgentColor } from "@/lib/agents";
+import type { SessionHistoryRecord } from "@/lib/redis";
+
+function formatDuration(ms: number): string {
+  if (ms < 60000) return `${Math.round(ms / 1000)}s`;
+  if (ms < 3600000) return `${Math.round(ms / 60000)}m`;
+  return `${(ms / 3600000).toFixed(1)}h`;
+}
+
+function relativeTime(iso: string): string {
+  const diffMs = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diffMs / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
+
+export function SessionHistory() {
+  const [records, setRecords] = useState<SessionHistoryRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const pollingActive = useRef(true);
+
+  async function refresh() {
+    if (!pollingActive.current) return;
+    try {
+      const res = await fetch("/api/sessions", { cache: "no-store" });
+      if (!res.ok) return;
+      const data = await res.json();
+      setRecords((data.history ?? []) as SessionHistoryRecord[]);
+    } catch { /* silent */ }
+    setLoading(false);
+  }
+
+  useEffect(() => {
+    pollingActive.current = true;
+    refresh();
+    const interval = setInterval(refresh, 30000);
+    const onVisibility = () => {
+      if (document.hidden) { pollingActive.current = false; }
+      else { pollingActive.current = true; refresh(); }
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => {
+      pollingActive.current = false;
+      clearInterval(interval);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Filter to today only
+  const today = new Date().toISOString().slice(0, 10);
+  const todayRecords = records.filter(r => r.completedAt.slice(0, 10) === today);
+
+  if (loading) return null;
+  if (todayRecords.length === 0) return null;
+
+  return (
+    <div className="rounded-xl border border-[#222] bg-[#161616] p-5">
+      <div className="flex items-center justify-between mb-4">
+        <div className="text-[10px] uppercase tracking-widest text-[#888] font-medium">
+          Sessions Today
+        </div>
+        <div className="text-[10px] text-[#444]">{todayRecords.length} completed</div>
+      </div>
+
+      <div className="space-y-0">
+        {todayRecords.map((r, i) => {
+          const color = getAgentColor(r.agentType);
+          const agentLabel = r.agentType.split("-").map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(" ");
+          return (
+            <div key={i} className="flex items-start gap-3 py-2.5 border-b border-[#1e1e1e] last:border-0">
+              {/* Color dot */}
+              <div className="mt-1 flex-shrink-0 w-1.5 h-1.5 rounded-full" style={{ background: color }} />
+
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 mb-0.5">
+                  <span className="text-[10px] font-medium" style={{ color }}>{agentLabel}</span>
+                  {r.project && (
+                    <>
+                      <span className="text-[10px] text-[#444]">·</span>
+                      <span className="text-[10px] text-[#555] font-mono">{r.project}</span>
+                    </>
+                  )}
+                  <span className="text-[10px] text-[#444]">·</span>
+                  <span className="text-[10px] text-[#444]">{relativeTime(r.completedAt)}</span>
+                </div>
+                {r.task && (
+                  <p className="text-xs text-[#666] leading-relaxed truncate">
+                    {r.task.length > 80 ? r.task.slice(0, 80) + "…" : r.task}
+                  </p>
+                )}
+              </div>
+
+              {/* Duration badge */}
+              {r.durationMs > 0 && (
+                <div className="flex-shrink-0 text-[10px] text-[#444] font-mono mt-0.5">
+                  {formatDuration(r.durationMs)}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -143,3 +143,38 @@ export async function getLoopEvents(limit = 50, offset = 0): Promise<LoopEventsR
     return { events: [], total: 0, totalErrors: 0, offset, limit };
   }
 }
+
+// ─── Session History ─────────────────────────────────────────────────────────
+
+const SESSION_HISTORY_KEY = "whitebox:session-history";
+const SESSION_HISTORY_CAP = 50;
+
+export interface SessionHistoryRecord {
+  agentType: string;
+  task: string;
+  project: string;
+  startedAt: string;
+  completedAt: string;
+  durationMs: number;
+}
+
+export async function pushSessionHistory(record: SessionHistoryRecord): Promise<void> {
+  const redis = getRedis();
+  if (!redis) return;
+  try {
+    await redis.lpush(SESSION_HISTORY_KEY, JSON.stringify(record));
+    await redis.ltrim(SESSION_HISTORY_KEY, 0, SESSION_HISTORY_CAP - 1);
+  } catch { /* silent */ }
+}
+
+export async function getSessionHistory(): Promise<SessionHistoryRecord[]> {
+  const redis = getRedis();
+  if (!redis) return [];
+  try {
+    const raw: string[] = await redis.lrange(SESSION_HISTORY_KEY, 0, SESSION_HISTORY_CAP - 1);
+    return raw.map(item => {
+      try { return JSON.parse(item) as SessionHistoryRecord; }
+      catch { return null; }
+    }).filter((r): r is SessionHistoryRecord => r !== null);
+  } catch { return []; }
+}


### PR DESCRIPTION
## Summary
- `pushSessionHistory` added to heartbeat `/completed` branch — records agentType, task, project, startedAt, completedAt, durationMs to Redis LPUSH list (capped at 50)
- `/api/sessions` now returns `history` array alongside sessions/activeTasks
- New `SessionHistory` client component polls `/api/sessions` every 30s, filters to today, renders timeline with agent color dots, task labels, duration badges, and relative timestamps
- Component added to dashboard below `<LiveSessions />`

## Test plan
- [ ] POST completed heartbeat → verify Redis key `whitebox:session-history` updated
- [ ] Dashboard loads → Sessions Today section appears (once at least one session has completed today)
- [ ] Records show correct agent color, task name truncated at 80 chars, duration badge
- [ ] Component hidden when no sessions today (clean dashboard when empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)