### PR TITLE
feat: show linked GitHub issue badge in Live Sessions panel (#126)

### DIFF
--- a/app/api/sessions/route.ts
+++ b/app/api/sessions/route.ts
@@ -47,6 +47,8 @@ export interface ActiveTaskFile {
   ageMinutes: number;
   /** True when last update was >10 minutes ago — agent may have stalled */
   isStale: boolean;
+  issueNumber?: number;
+  issueRepo?: string;
 }
 
 const STALE_THRESHOLD_MS = 10 * 60 * 1000; // 10 minutes
@@ -87,6 +89,8 @@ interface TaskEntry {
   project: string;
   projectPath: string;
   updatedAt: string;
+  issueNumber?: number;
+  issueRepo?: string;
 }
 
 function buildTaskMaps(): {
@@ -131,7 +135,12 @@ function buildTaskMaps(): {
       const explicitAgentType = lines[2] ?? null;
       const agentType = explicitAgentType || inferAgentType(label);
 
-      const entry: TaskEntry = { label, agentType, project, projectPath, updatedAt };
+      // line 4 = issue number, line 5 = issue repo (optional)
+      const rawIssueNum = lines[3] ?? "";
+      const issueNumber = rawIssueNum ? (parseInt(rawIssueNum.replace(/^#/, "")) || undefined) : undefined;
+      const issueRepo = lines[4] ?? undefined;
+
+      const entry: TaskEntry = { label, agentType, project, projectPath, updatedAt, issueNumber, issueRepo };
 
       // New format: line 2 is PID
       const pid = parseInt(lines[1] ?? "");
@@ -293,7 +302,7 @@ export async function GET() {
             titled = false;
           }
 
-          sessions.push({ pid, cpu, mem, started, elapsed, sessionId, cwd, project, label, agentType, title, titled, flags });
+          sessions.push({ pid, cpu, mem, started, elapsed, sessionId, cwd, project, label, agentType, title, titled, flags, issueNumber: task?.issueNumber, issueRepo: task?.issueRepo });
         }
 
         sessions.sort((a, b) => b.cpu - a.cpu);
@@ -308,6 +317,8 @@ export async function GET() {
             updatedAt: e.updatedAt,
             ageMinutes: Math.round(e.ageMinutes),
             isStale: e.ageMinutes * 60 * 1000 > STALE_THRESHOLD_MS,
+            issueNumber: e.issueNumber,
+            issueRepo: e.issueRepo,
           }));
       } catch {
         // ps aux failed (expected on Vercel)

--- a/components/LiveSessions.tsx
+++ b/components/LiveSessions.tsx
@@ -120,6 +120,16 @@ export function LiveSessions() {
                   {s.project && (
                     <span className="text-[10px] text-[#777]">{s.project}</span>
                   )}
+                  {s.issueNumber && s.issueRepo && (
+                    <a
+                      href={`https://github.com/${s.issueRepo}/issues/${s.issueNumber}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-[10px] text-[#777] bg-[#1a1a1a] px-1 py-0.5 rounded hover:text-[#aaa] transition-colors"
+                    >
+                      #{s.issueNumber}
+                    </a>
+                  )}
                   {s.flags.map(f => (
                     <span key={f} className="text-[10px] text-[#777] bg-[#1a1a1a] px-1 py-0.5 rounded">{f}</span>
                   ))}
@@ -148,9 +158,21 @@ export function LiveSessions() {
                     Stale · {t.ageMinutes}m ago
                   </span>
                 </div>
-                {t.project && (
-                  <span className="text-[10px] text-[#555]">{t.project}</span>
-                )}
+                <div className="flex items-center gap-2 mt-0.5">
+                  {t.project && (
+                    <span className="text-[10px] text-[#555]">{t.project}</span>
+                  )}
+                  {t.issueNumber && t.issueRepo && (
+                    <a
+                      href={`https://github.com/${t.issueRepo}/issues/${t.issueNumber}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-[10px] text-[#555] bg-[#1a1a1a] px-1 py-0.5 rounded hover:text-[#888] transition-colors"
+                    >
+                      #{t.issueNumber}
+                    </a>
+                  )}
+                </div>
               </div>
             </div>
           ))}


### PR DESCRIPTION
## Summary
- Added `issueNumber`/`issueRepo` fields to `TaskEntry` and `ActiveTaskFile` interfaces
- Parse from cc-task file lines 4 (issue number, strips leading `#`) and 5 (repo like `wkliwk/whitebox`)
- Populate on `sessions.push()` and `activeTasks` mapping in `/api/sessions`
- `LiveSessions.tsx`: renders `#N` badge as clickable link (opens new tab) next to project label for both live sessions and stale task rows

## Test plan
- [ ] When cc-task file has issue number in line 4, session row shows `#N` badge linking to GitHub
- [ ] Badge opens in new tab
- [ ] Sessions without issueNumber: no badge, no regression
- [ ] Stale task rows with issueNumber show badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)