### PR TITLE
feat: session history grouped by day (#127)

### DIFF
--- a/components/SessionHistory.tsx
+++ b/components/SessionHistory.tsx
@@ -20,6 +20,16 @@ function relativeTime(iso: string): string {
   return `${Math.floor(hrs / 24)}d ago`;
 }
 
+function dayLabel(dateStr: string): string {
+  const today = new Date().toISOString().slice(0, 10);
+  const yesterday = new Date(Date.now() - 86400000).toISOString().slice(0, 10);
+  if (dateStr === today) return "Today";
+  if (dateStr === yesterday) return "Yesterday";
+  // e.g. "Apr 1"
+  const d = new Date(dateStr + "T12:00:00Z");
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
 export function SessionHistory() {
   const [records, setRecords] = useState<SessionHistoryRecord[]>([]);
   const [loading, setLoading] = useState(true);
@@ -53,59 +63,77 @@ export function SessionHistory() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Filter to today only
-  const today = new Date().toISOString().slice(0, 10);
-  const todayRecords = records.filter(r => r.completedAt.slice(0, 10) === today);
-
   if (loading) return null;
-  if (todayRecords.length === 0) return null;
+  if (records.length === 0) return null;
+
+  // Group by day (YYYY-MM-DD), preserving order (newest first)
+  const groups: { date: string; items: SessionHistoryRecord[] }[] = [];
+  for (const r of records) {
+    const date = r.completedAt.slice(0, 10);
+    const last = groups[groups.length - 1];
+    if (last && last.date === date) {
+      last.items.push(r);
+    } else {
+      groups.push({ date, items: [r] });
+    }
+  }
 
   return (
     <div className="rounded-xl border border-[#222] bg-[#161616] p-5">
       <div className="flex items-center justify-between mb-4">
         <div className="text-[10px] uppercase tracking-widest text-[#888] font-medium">
-          Sessions Today
+          Session History
         </div>
-        <div className="text-[10px] text-[#444]">{todayRecords.length} completed</div>
+        <div className="text-[10px] text-[#444]">{records.length} completed</div>
       </div>
 
-      <div className="space-y-0">
-        {todayRecords.map((r, i) => {
-          const color = getAgentColor(r.agentType);
-          const agentLabel = r.agentType.split("-").map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(" ");
-          return (
-            <div key={i} className="flex items-start gap-3 py-2.5 border-b border-[#1e1e1e] last:border-0">
-              {/* Color dot */}
-              <div className="mt-1 flex-shrink-0 w-1.5 h-1.5 rounded-full" style={{ background: color }} />
-
-              <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-2 mb-0.5">
-                  <span className="text-[10px] font-medium" style={{ color }}>{agentLabel}</span>
-                  {r.project && (
-                    <>
-                      <span className="text-[10px] text-[#444]">·</span>
-                      <span className="text-[10px] text-[#555] font-mono">{r.project}</span>
-                    </>
-                  )}
-                  <span className="text-[10px] text-[#444]">·</span>
-                  <span className="text-[10px] text-[#444]">{relativeTime(r.completedAt)}</span>
-                </div>
-                {r.task && (
-                  <p className="text-xs text-[#666] leading-relaxed truncate">
-                    {r.task.length > 80 ? r.task.slice(0, 80) + "…" : r.task}
-                  </p>
-                )}
-              </div>
-
-              {/* Duration badge */}
-              {r.durationMs > 0 && (
-                <div className="flex-shrink-0 text-[10px] text-[#444] font-mono mt-0.5">
-                  {formatDuration(r.durationMs)}
-                </div>
-              )}
+      <div className="space-y-4">
+        {groups.map(group => (
+          <div key={group.date}>
+            {/* Day header */}
+            <div className="flex items-center justify-between mb-1.5">
+              <div className="text-[10px] text-[#555] font-medium">{dayLabel(group.date)}</div>
+              <div className="text-[10px] text-[#3a3a3a]">{group.items.length} completed</div>
             </div>
-          );
-        })}
+
+            <div className="space-y-0">
+              {group.items.map((r, i) => {
+                const color = getAgentColor(r.agentType);
+                const agentLabel = r.agentType.split("-").map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(" ");
+                return (
+                  <div key={i} className="flex items-start gap-3 py-2.5 border-b border-[#1e1e1e] last:border-0">
+                    <div className="mt-1 flex-shrink-0 w-1.5 h-1.5 rounded-full" style={{ background: color }} />
+
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 mb-0.5">
+                        <span className="text-[10px] font-medium" style={{ color }}>{agentLabel}</span>
+                        {r.project && (
+                          <>
+                            <span className="text-[10px] text-[#444]">·</span>
+                            <span className="text-[10px] text-[#555] font-mono">{r.project}</span>
+                          </>
+                        )}
+                        <span className="text-[10px] text-[#444]">·</span>
+                        <span className="text-[10px] text-[#444]">{relativeTime(r.completedAt)}</span>
+                      </div>
+                      {r.task && (
+                        <p className="text-xs text-[#666] leading-relaxed truncate">
+                          {r.task.length > 120 ? r.task.slice(0, 120) + "…" : r.task}
+                        </p>
+                      )}
+                    </div>
+
+                    {r.durationMs > 0 && (
+                      <div className="flex-shrink-0 text-[10px] text-[#444] font-mono mt-0.5">
+                        {formatDuration(r.durationMs)}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        ))}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Removed today-only filter — shows all 50 records from Redis
- Groups records by day with `Today` / `Yesterday` / `Apr 1` headers
- Per-day record count shown right-aligned in each group header
- Task truncation increased from 80 → 120 chars
- Empty state (no records) still renders nothing

## Test plan
- [ ] Records from multiple days appear in separate groups with correct labels
- [ ] Each group header shows correct count
- [ ] No records → component renders nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)