### PR TITLE
feat: show recently closed issues in Issues page (#128)

### DIFF
--- a/lib/github.ts
+++ b/lib/github.ts
@@ -97,37 +97,63 @@ export async function getOpenPRs(): Promise<PullRequest[]> {
   return prs.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
 }
 
+function parseIssueToTask(issue: any, repo: string, forceStatus?: RecentTask["status"]): RecentTask | null {
+  if (issue.pull_request) return null;
+  const labels = issue.labels.map((l: any) => typeof l === "object" ? l.name || "" : l) as string[];
+  let status: RecentTask["status"] = forceStatus ?? "todo";
+  if (!forceStatus && labels.some((l: string) => l.includes("in-progress"))) status = "in-progress";
+  let priority: RecentTask["priority"] = "p2";
+  if (labels.some((l: string) => l.includes("p0"))) priority = "p0";
+  else if (labels.some((l: string) => l.includes("p1"))) priority = "p1";
+  const agentLabel = labels.find((l: string) => l.startsWith("agent:"));
+  const agent = agentLabel?.replace("agent:", "");
+  return { number: issue.number, title: issue.title, status, priority, agent, updatedAt: issue.updated_at, url: issue.html_url, repo };
+}
+
 export async function getRecentTasks(): Promise<RecentTask[]> {
   if (!process.env.GITHUB_TOKEN) return [];
 
   const octokit = await getOctokit();
   const repos = getProductRepos();
-  const tasks: RecentTask[] = [];
 
-  // Fetch all repos in parallel
-  const results = await Promise.allSettled(
-    repos.map(({ owner, name: repo }) =>
-      octokit.rest.issues.listForRepo({ owner, repo, state: "open", sort: "updated", per_page: 20, direction: "desc" })
-        .then(({ data }: { data: any[] }) => ({ repo, data }))
-    )
-  );
+  // Fetch open and recently closed issues in parallel across all repos
+  const [openResults, closedResults] = await Promise.all([
+    Promise.allSettled(
+      repos.map(({ owner, name: repo }) =>
+        octokit.rest.issues.listForRepo({ owner, repo, state: "open", sort: "updated", per_page: 20, direction: "desc" })
+          .then(({ data }: { data: any[] }) => ({ repo, data }))
+      )
+    ),
+    Promise.allSettled(
+      repos.map(({ owner, name: repo }) =>
+        octokit.rest.issues.listForRepo({ owner, repo, state: "closed", sort: "updated", per_page: 10, direction: "desc" })
+          .then(({ data }: { data: any[] }) => ({ repo, data }))
+      )
+    ),
+  ]);
 
-  for (const result of results) {
+  const openTasks: RecentTask[] = [];
+  for (const result of openResults) {
     if (result.status !== "fulfilled") continue;
     const { repo, data } = result.value;
     for (const issue of data) {
-      if (issue.pull_request) continue;
-      const labels = issue.labels.map((l: any) => typeof l === "object" ? l.name || "" : l) as string[];
-      let status: RecentTask["status"] = "todo";
-      if (labels.some((l: string) => l.includes("in-progress"))) status = "in-progress";
-      let priority: RecentTask["priority"] = "p2";
-      if (labels.some((l: string) => l.includes("p0"))) priority = "p0";
-      else if (labels.some((l: string) => l.includes("p1"))) priority = "p1";
-      const agentLabel = labels.find((l: string) => l.startsWith("agent:"));
-      const agent = agentLabel?.replace("agent:", "");
-      tasks.push({ number: issue.number, title: issue.title, status, priority, agent, updatedAt: issue.updated_at, url: issue.html_url, repo });
+      const task = parseIssueToTask(issue, repo);
+      if (task) openTasks.push(task);
     }
   }
 
-  return tasks.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()).slice(0, 20);
+  const closedTasks: RecentTask[] = [];
+  for (const result of closedResults) {
+    if (result.status !== "fulfilled") continue;
+    const { repo, data } = result.value;
+    for (const issue of data) {
+      const task = parseIssueToTask(issue, repo, "done");
+      if (task) closedTasks.push(task);
+    }
+  }
+
+  const sorted = (arr: RecentTask[]) =>
+    arr.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+
+  return [...sorted(openTasks), ...sorted(closedTasks)].slice(0, 30);
 }


### PR DESCRIPTION
## Summary
- Extracted `parseIssueToTask()` helper to deduplicate label parsing
- Added parallel `state: "closed"` fetch (10 per repo) in `getRecentTasks()`
- Closed issues mapped to `status: "done"`
- Open issues (sorted) followed by closed issues (sorted), capped at 30 total
- `IssuesFilter` and Issues page "Done" stat card now show real data

## Test plan
- [ ] Issues page shows recently closed issues in the Done section
- [ ] Done stat card shows non-zero count
- [ ] Open issues appear first, closed issues at bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)