### PR TITLE
fix: per-repo issue cap for fair representation (#129)

### DIFF
--- a/lib/github.ts
+++ b/lib/github.ts
@@ -120,7 +120,7 @@ export async function getRecentTasks(): Promise<RecentTask[]> {
   const [openResults, closedResults] = await Promise.all([
     Promise.allSettled(
       repos.map(({ owner, name: repo }) =>
-        octokit.rest.issues.listForRepo({ owner, repo, state: "open", sort: "updated", per_page: 20, direction: "desc" })
+        octokit.rest.issues.listForRepo({ owner, repo, state: "open", sort: "updated", per_page: 10, direction: "desc" })
           .then(({ data }: { data: any[] }) => ({ repo, data }))
       )
     ),
@@ -155,5 +155,6 @@ export async function getRecentTasks(): Promise<RecentTask[]> {
   const sorted = (arr: RecentTask[]) =>
     arr.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
 
-  return [...sorted(openTasks), ...sorted(closedTasks)].slice(0, 30);
+  const cap = Math.max(repos.length * 10, 30);
+  return [...sorted(openTasks), ...sorted(closedTasks)].slice(0, cap);
 }


### PR DESCRIPTION
## Summary
- `per_page: 20 → 10` for open issues (already 10 for closed)
- Global cap changed from fixed 30 to `repos.length * 10` (min 30) — with 5 repos you get up to 50 issues fairly distributed
- No single repo can flood the list

## Test plan
- [ ] With multiple repos tracked, issues from all repos appear in the list
- [ ] Total count scales with number of repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)