### PR TITLE
feat: 7-day cost sparklines in agent cost breakdown (#130)

### DIFF
--- a/app/api/costs/history/route.ts
+++ b/app/api/costs/history/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+import { getCostHistory } from "@/lib/redis";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const history = await getCostHistory();
+  return NextResponse.json({ history, updatedAt: new Date().toISOString() });
+}

--- a/app/api/costs/snapshot/route.ts
+++ b/app/api/costs/snapshot/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { pushCostSnapshot, type DailyCostSnapshot } from "@/lib/redis";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(req: Request) {
+  const token = process.env.WHITEBOX_PUSH_TOKEN;
+  if (token) {
+    const auth = req.headers.get("authorization");
+    if (auth !== `Bearer ${token}`) {
+      return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+    }
+  }
+
+  const body = await req.json() as Partial<DailyCostSnapshot>;
+  const { date, totalSpend, byAgent } = body;
+
+  if (!date || totalSpend === undefined || !byAgent) {
+    return NextResponse.json({ error: "date, totalSpend, and byAgent required" }, { status: 400 });
+  }
+
+  await pushCostSnapshot({ date, totalSpend, byAgent });
+  return NextResponse.json({ ok: true, date });
+}

--- a/components/AgentCostBreakdown.tsx
+++ b/components/AgentCostBreakdown.tsx
@@ -1,12 +1,53 @@
+"use client";
+
+import { useEffect, useState } from "react";
 import { getAgentColor } from "@/lib/agents";
 import { formatCents } from "@/lib/utils";
 import type { CostReport } from "@/lib/costs";
+import type { DailyCostSnapshot } from "@/lib/redis";
 
 interface Props {
   report: CostReport | null;
 }
 
+/** Inline div-based sparkline — no chart lib dependency */
+function Sparkline({ values, color }: { values: number[]; color: string }) {
+  const max = Math.max(...values, 1);
+  return (
+    <div className="flex items-end gap-px" style={{ width: 48, height: 16 }}>
+      {values.map((v, i) => (
+        <div
+          key={i}
+          className="flex-1 rounded-sm"
+          style={{
+            height: `${Math.max(2, Math.round((v / max) * 16))}px`,
+            background: v > 0 ? color : "#2a2a2a",
+            opacity: v > 0 ? 0.7 : 0.3,
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
 export function AgentCostBreakdown({ report }: Props) {
+  const [history, setHistory] = useState<DailyCostSnapshot[]>([]);
+
+  useEffect(() => {
+    fetch("/api/costs/history", { cache: "no-store" })
+      .then(r => r.ok ? r.json() : null)
+      .then(d => { if (d?.history) setHistory(d.history); })
+      .catch(() => {});
+  }, []);
+
+  // Build last-7-days date strings (newest first → oldest last for display)
+  const last7: string[] = [];
+  for (let i = 6; i >= 0; i--) {
+    last7.push(new Date(Date.now() - i * 86400000).toISOString().slice(0, 10));
+  }
+  const historyMap = new Map(history.map(s => [s.date, s]));
+  const hasSparklines = history.length >= 2;
+
   const header = (
     <div className="text-[10px] uppercase tracking-widest text-[#888] font-medium mb-3">
       Agent Cost Breakdown
@@ -35,6 +76,7 @@ export function AgentCostBreakdown({ report }: Props) {
         {entries.map(({ agent, cents }) => {
           const pct = total > 0 ? Math.round((cents / total) * 100) : 0;
           const color = getAgentColor(agent);
+          const sparkValues = last7.map(d => historyMap.get(d)?.byAgent[agent] ?? 0);
           return (
             <div key={agent}>
               <div className="flex items-center justify-between text-xs mb-1">
@@ -42,7 +84,10 @@ export function AgentCostBreakdown({ report }: Props) {
                   <div className="w-2 h-2 rounded-full flex-shrink-0" style={{ background: color }} />
                   <span className="text-[#ccc] capitalize">{agent}</span>
                 </div>
-                <div className="flex items-center gap-2 text-[#888]">
+                <div className="flex items-center gap-3 text-[#888]">
+                  {hasSparklines && (
+                    <Sparkline values={sparkValues} color={color} />
+                  )}
                   <span>{formatCents(cents)}</span>
                   <span className="text-[#555] w-7 text-right">{pct}%</span>
                 </div>

--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -178,3 +178,35 @@ export async function getSessionHistory(): Promise<SessionHistoryRecord[]> {
     }).filter((r): r is SessionHistoryRecord => r !== null);
   } catch { return []; }
 }
+
+// ─── Cost History ─────────────────────────────────────────────────────────────
+
+const COST_HISTORY_KEY = "whitebox:cost-history";
+const COST_HISTORY_CAP = 14; // 2 weeks of daily snapshots
+
+export interface DailyCostSnapshot {
+  date: string; // "YYYY-MM-DD"
+  totalSpend: number;
+  byAgent: Record<string, number>;
+}
+
+export async function pushCostSnapshot(snapshot: DailyCostSnapshot): Promise<void> {
+  const redis = getRedis();
+  if (!redis) return;
+  try {
+    await redis.lpush(COST_HISTORY_KEY, JSON.stringify(snapshot));
+    await redis.ltrim(COST_HISTORY_KEY, 0, COST_HISTORY_CAP - 1);
+  } catch { /* silent */ }
+}
+
+export async function getCostHistory(): Promise<DailyCostSnapshot[]> {
+  const redis = getRedis();
+  if (!redis) return [];
+  try {
+    const raw: string[] = await redis.lrange(COST_HISTORY_KEY, 0, COST_HISTORY_CAP - 1);
+    return raw.map(item => {
+      try { return JSON.parse(item) as DailyCostSnapshot; }
+      catch { return null; }
+    }).filter((r): r is DailyCostSnapshot => r !== null);
+  } catch { return []; }
+}


### PR DESCRIPTION
## Summary
- `lib/redis.ts` — `DailyCostSnapshot` type, `pushCostSnapshot()` (LPUSH+LTRIM 14), `getCostHistory()`
- `app/api/costs/history/route.ts` — GET endpoint, returns stored snapshots
- `app/api/costs/snapshot/route.ts` — POST endpoint, protected by `WHITEBOX_PUSH_TOKEN`, pushes daily snapshot
- `components/AgentCostBreakdown.tsx` — converted to client component, fetches history on mount, renders inline div-based sparkline per agent row when ≥2 days of data exist

## Test plan
- [ ] `POST /api/costs/snapshot` with valid token stores snapshot in Redis
- [ ] `GET /api/costs/history` returns snapshots array
- [ ] AgentCostBreakdown sparklines appear after pushing 2+ snapshots
- [ ] No sparklines when history < 2 days (no broken UI)
- [ ] Existing bar chart layout unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)