### PR TITLE
feat: linked issue badge in session history (#136)

### DIFF
--- a/app/api/heartbeat/route.ts
+++ b/app/api/heartbeat/route.ts
@@ -48,6 +48,8 @@ export async function POST(req: Request) {
         startedAt,
         completedAt,
         durationMs,
+        issueNumber: issueNumber ?? undefined,
+        issueRepo: issueRepo ?? undefined,
       }),
     ]);
     return NextResponse.json({ ok, agentType, status });

--- a/components/SessionHistory.tsx
+++ b/components/SessionHistory.tsx
@@ -113,6 +113,16 @@ export function SessionHistory() {
                             <span className="text-[10px] text-[#555] font-mono">{r.project}</span>
                           </>
                         )}
+                        {r.issueNumber && r.issueRepo && (
+                          <a
+                            href={`https://github.com/${r.issueRepo}/issues/${r.issueNumber}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-[10px] text-[#777] bg-[#1a1a1a] px-1 py-0.5 rounded hover:text-[#aaa] transition-colors"
+                          >
+                            #{r.issueNumber}
+                          </a>
+                        )}
                         <span className="text-[10px] text-[#444]">·</span>
                         <span className="text-[10px] text-[#444]">{relativeTime(r.completedAt)}</span>
                       </div>

--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -156,6 +156,8 @@ export interface SessionHistoryRecord {
   startedAt: string;
   completedAt: string;
   durationMs: number;
+  issueNumber?: number;
+  issueRepo?: string;
 }
 
 export async function pushSessionHistory(record: SessionHistoryRecord): Promise<void> {


### PR DESCRIPTION
## Summary
- Added `issueNumber?`/`issueRepo?` to `SessionHistoryRecord` in `lib/redis.ts`
- Heartbeat completed branch now passes those fields to `pushSessionHistory()`
- `SessionHistory.tsx`: renders `#N` badge as `<a target="_blank">` next to project label when both fields present

## Test plan
- [ ] Complete a heartbeat with issueNumber/issueRepo → session history row shows #N badge
- [ ] Sessions without issueNumber: no badge, no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)