### PR TITLE
feat: auto-write cost snapshot on heartbeat completion (#140)

### DIFF
--- a/app/api/heartbeat/route.ts
+++ b/app/api/heartbeat/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { writeHeartbeat, removeHeartbeat, getAllHeartbeats, setAgentLastTask, pushSessionHistory, type Heartbeat } from "@/lib/redis";
+import { writeDailyCostSnapshot } from "@/lib/costs";
 
 export const dynamic = "force-dynamic";
 
@@ -52,6 +53,8 @@ export async function POST(req: Request) {
         issueRepo: issueRepo ?? undefined,
       }),
     ]);
+    // Fire-and-forget — snapshot the current costs.json into Redis history
+    writeDailyCostSnapshot();
     return NextResponse.json({ ok, agentType, status });
   }
 

--- a/lib/costs.ts
+++ b/lib/costs.ts
@@ -24,3 +24,24 @@ export function budgetPct(report: CostReport): number {
   if (!report.budget) return 0;
   return Math.min(100, Math.round((report.mtdSpend / report.budget) * 100));
 }
+
+/**
+ * Read costs.json from cwd and push a daily snapshot to Redis.
+ * Fire-and-forget — never throws.
+ */
+export async function writeDailyCostSnapshot(): Promise<void> {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const fs = require("fs") as typeof import("fs");
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const path = require("path") as typeof import("path");
+    const raw = fs.readFileSync(path.join(process.cwd(), "costs.json"), "utf-8");
+    const report = JSON.parse(raw) as CostReport;
+    const { pushCostSnapshot } = await import("./redis");
+    await pushCostSnapshot({
+      date: new Date().toISOString().slice(0, 10),
+      totalSpend: report.mtdSpend,
+      byAgent: report.byAgent ?? {},
+    });
+  } catch { /* silent — costs.json may not exist on Vercel */ }
+}


### PR DESCRIPTION
## Summary
- `lib/costs.ts` — `writeDailyCostSnapshot()`: reads `costs.json` from cwd, pushes to Redis via `pushCostSnapshot()`; fails silently if file missing (Vercel-safe)
- `app/api/heartbeat/route.ts` — calls `writeDailyCostSnapshot()` fire-and-forget after every `completed` heartbeat; heartbeat response unaffected by snapshot failures

## Test plan
- [ ] Send completed heartbeat → check Redis `whitebox:cost-history` has a new entry for today
- [ ] Heartbeat returns 200 even if costs.json missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)