### PR TITLE
feat: agent label badge in loop log events (#138)

### DIFF
--- a/components/LoopLog.tsx
+++ b/components/LoopLog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { getAgentColor } from "@/lib/agents";
 import type { LogEntry } from "@/lib/local";
 
 const PAGE_SIZE = 50;
@@ -114,6 +115,16 @@ export function LoopLog({ entries: initialEntries, total: initialTotal, totalErr
                       {e.product}
                     </span>
                   )}
+                  {e.agent && e.agent !== "loop" && (() => {
+                    const ac = getAgentColor(e.agent);
+                    const al = e.agent.split("-").map((w: string) => w.charAt(0).toUpperCase() + w.slice(1)).join(" ");
+                    return (
+                      <span className="text-[10px] font-medium px-1.5 py-0.5 rounded shrink-0"
+                        style={{ background: ac + "22", color: ac }}>
+                        {al}
+                      </span>
+                    );
+                  })()}
                   <span className="text-xs leading-relaxed" style={{ color: s.text }}>{e.action}</span>
                 </div>
               );

--- a/lib/local.ts
+++ b/lib/local.ts
@@ -110,6 +110,7 @@ export interface LogEntry {
   product: string;
   action: string;
   level: "info" | "warn" | "error" | "debug";
+  agent?: string;
 }
 
 function classifyLevel(action: string): LogEntry["level"] {


### PR DESCRIPTION
## Summary
- `lib/local.ts` — `agent?` added to `LogEntry` interface
- `components/LoopLog.tsx` — renders colored agent pill when `e.agent` is set and is not `"loop"`
- `~/.claude/log-loop-event.sh` — accepts optional 3rd arg for agent type; falls back to `"loop"` when not provided; also writes agent to local log file

## Test plan
- [ ] Push an event with `log-loop-event.sh "test" info dev` → `/logs` shows "Dev" badge in cyan
- [ ] Events without agent arg continue to work (no badge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)