### PR TITLE
feat: today's spend in TodayGlance + auto-refresh Loop Log (#148, #149)

### DIFF
--- a/app/api/sessions/route.ts
+++ b/app/api/sessions/route.ts
@@ -7,7 +7,7 @@ const os = require("os") as typeof import("os");
 import { NextResponse } from "next/server";
 // Dynamic import to avoid TDZ issues with webpack externalization
 import { getProductRepos } from "@/lib/local";
-import { getAllHeartbeats, getSessionHistory } from "@/lib/redis";
+import { getAllHeartbeats, getSessionHistory, getCostHistory } from "@/lib/redis";
 import { withCache } from "@/lib/cache";
 
 export const dynamic = "force-dynamic";
@@ -325,7 +325,9 @@ export async function GET() {
       }
 
       // Always merge Redis heartbeats — they carry agent type info that ps aux lacks
-      const [heartbeats, history] = await Promise.all([getAllHeartbeats(), getSessionHistory()]);
+      const today = new Date().toISOString().slice(0, 10);
+      const [heartbeats, history, costHistory] = await Promise.all([getAllHeartbeats(), getSessionHistory(), getCostHistory()]);
+      const todaySpend = costHistory.find(s => s.date === today)?.totalSpend ?? null;
       const seenAgentTypes = new Set(activeTasks.map(t => t.agentType).filter(Boolean));
       for (const hb of heartbeats) {
         // Skip if we already have a local task file for this agent type
@@ -347,7 +349,7 @@ export async function GET() {
         activeTasks = await fetchGitHubActiveTasks();
       }
 
-      return { sessions, activeTasks, history, updatedAt: new Date().toISOString() };
+      return { sessions, activeTasks, history, todaySpend, updatedAt: new Date().toISOString() };
     });
 
     return NextResponse.json(data);

--- a/components/LoopLog.tsx
+++ b/components/LoopLog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { getAgentColor } from "@/lib/agents";
 import type { LogEntry } from "@/lib/local";
 
@@ -32,6 +32,11 @@ export function LoopLog({ entries: initialEntries, total: initialTotal, totalErr
   const [loading, setLoading] = useState(false);
   const [isClient, setIsClient] = useState(false);
   const [isProduction, setIsProduction] = useState(false);
+  const [secondsSince, setSecondsSince] = useState(0);
+  const lastFetchedAt = useRef<number>(0);
+  const pollingActive = useRef(true);
+  const offsetRef = useRef(offset);
+  offsetRef.current = offset;
 
   useEffect(() => {
     setIsClient(true);
@@ -47,9 +52,43 @@ export function LoopLog({ entries: initialEntries, total: initialTotal, totalErr
       setTotal(data.total ?? 0);
       setTotalErrors(data.totalErrors ?? 0);
       setOffset(newOffset);
+      lastFetchedAt.current = Date.now();
+      setSecondsSince(0);
     } catch { /* retain current page */ }
     setLoading(false);
   }
+
+  // Auto-poll every 20s on page 0 when tab is visible (production only)
+  useEffect(() => {
+    if (!isProduction) return;
+    pollingActive.current = true;
+
+    const poll = () => {
+      if (pollingActive.current && offsetRef.current === 0) fetchPage(0);
+    };
+    const intervalId = setInterval(poll, 20000);
+
+    const onVisibility = () => {
+      if (document.hidden) { pollingActive.current = false; }
+      else { pollingActive.current = true; if (offsetRef.current === 0) fetchPage(0); }
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+
+    return () => {
+      pollingActive.current = false;
+      clearInterval(intervalId);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isProduction]);
+
+  // "Updated Xs ago" tick
+  useEffect(() => {
+    const tickId = setInterval(() => {
+      if (lastFetchedAt.current > 0) setSecondsSince(Math.floor((Date.now() - lastFetchedAt.current) / 1000));
+    }, 1000);
+    return () => clearInterval(tickId);
+  }, []);
 
   // For local dev, slice the server-provided flat array; for production, use fetched page
   const visibleEntries = (!isClient || !isProduction)
@@ -90,6 +129,11 @@ export function LoopLog({ entries: initialEntries, total: initialTotal, totalErr
           {effectiveTotal > PAGE_SIZE && (
             <span className="text-[10px] text-[#555]">
               {start}–{end} of {effectiveTotal}
+            </span>
+          )}
+          {isProduction && lastFetchedAt.current > 0 && (
+            <span className="text-[10px] text-[#444]">
+              {secondsSince < 5 ? "just now" : `${secondsSince}s ago`}
             </span>
           )}
         </div>

--- a/components/TodayGlance.tsx
+++ b/components/TodayGlance.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { formatSpend } from "@/lib/costs";
 import type { SessionHistoryRecord } from "@/lib/redis";
 import type { RecentTask } from "@/lib/github";
 
@@ -20,6 +21,7 @@ interface Props {
 
 export function TodayGlance({ doneTasks }: Props) {
   const [history, setHistory] = useState<SessionHistoryRecord[]>([]);
+  const [todaySpend, setTodaySpend] = useState<number | null>(null);
   const pollingActive = useRef(true);
 
   useEffect(() => {
@@ -31,6 +33,7 @@ export function TodayGlance({ doneTasks }: Props) {
         if (res.ok) {
           const data = await res.json();
           setHistory((data.history ?? []) as SessionHistoryRecord[]);
+          setTodaySpend(data.todaySpend ?? null);
         }
       } catch { /* silent */ }
     };
@@ -63,6 +66,8 @@ export function TodayGlance({ doneTasks }: Props) {
       {stat(formatActiveTime(activeMsTotal), "active")}
       <div className="w-px h-3 bg-[#2a2a2a]" />
       {stat(issuesClosedToday || "—", issuesClosedToday === 1 ? "issue closed" : "issues closed")}
+      <div className="w-px h-3 bg-[#2a2a2a]" />
+      {stat(todaySpend !== null ? formatSpend(todaySpend) : "—", "spent today")}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

**#149 — Today's spend in TodayGlance**
- `app/api/sessions/route.ts`: imports `getCostHistory`, finds today's snapshot, returns `todaySpend` (null if absent)
- `components/TodayGlance.tsx`: 4th stat pill using `formatSpend()` from `lib/costs.ts`; shows `—` when no snapshot

**#148 — Auto-refresh Loop Log**
- `components/LoopLog.tsx`: 20s poll on page 0 (production only), pauses on `visibilitychange`, resumes + immediate fetch on tab focus; "Updated Xs ago" counter in header

## Test plan
- [ ] TodayGlance shows spend stat after at least one heartbeat completes
- [ ] Loop Log refreshes automatically every 20s on production
- [ ] Pagination to page 2+ stops auto-refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)