### PR TITLE
feat: live-refresh Issues page every 30s (#147)

### DIFF
--- a/app/api/issues/route.ts
+++ b/app/api/issues/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+import { getRecentTasks } from "@/lib/github";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const tasks = await getRecentTasks();
+  return NextResponse.json({ tasks, updatedAt: new Date().toISOString() });
+}

--- a/app/issues/page.tsx
+++ b/app/issues/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { Suspense } from "react";
 import { Sidebar } from "@/components/Sidebar";
-import { IssuesFilter } from "@/components/IssuesFilter";
+import { IssuesClient } from "@/components/IssuesClient";
 import { getProductRepos } from "@/lib/local";
 import { getRecentTasks } from "@/lib/github";
 import { PRODUCTS } from "@/lib/products";
@@ -112,9 +112,9 @@ export default async function IssuesPage({
             ))}
           </div>
 
-          {/* Filtered task list with client-side search */}
+          {/* Filtered task list with live polling + client-side search */}
           <Suspense fallback={<div className="text-xs text-[#555] py-4">Loading…</div>}>
-            <IssuesFilter tasks={repoFiltered} initialQuery={initialQuery ?? ""} />
+            <IssuesClient initialTasks={tasks} initialQuery={initialQuery ?? ""} activeRepo={activeRepo} />
           </Suspense>
         </div>
       </main>

--- a/components/IssuesClient.tsx
+++ b/components/IssuesClient.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { IssuesFilter } from "@/components/IssuesFilter";
+import type { RecentTask } from "@/lib/github";
+
+interface Props {
+  initialTasks: RecentTask[];
+  initialQuery?: string;
+  activeRepo?: string;
+}
+
+export function IssuesClient({ initialTasks, initialQuery = "", activeRepo }: Props) {
+  const [tasks, setTasks] = useState<RecentTask[]>(initialTasks);
+  const [secondsSince, setSecondsSince] = useState(0);
+  const lastFetchedAt = useRef<number>(0);
+  const pollingActive = useRef(true);
+
+  async function refresh() {
+    if (!pollingActive.current) return;
+    try {
+      const res = await fetch("/api/issues", { cache: "no-store" });
+      if (res.ok) {
+        const data = await res.json();
+        setTasks(data.tasks ?? []);
+        lastFetchedAt.current = Date.now();
+        setSecondsSince(0);
+      }
+    } catch { /* retain current */ }
+  }
+
+  useEffect(() => {
+    pollingActive.current = true;
+    const interval = setInterval(refresh, 30000);
+    const onVisibility = () => {
+      if (document.hidden) { pollingActive.current = false; }
+      else { pollingActive.current = true; refresh(); }
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => {
+      pollingActive.current = false;
+      clearInterval(interval);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    const tickId = setInterval(() => {
+      if (lastFetchedAt.current > 0) setSecondsSince(Math.floor((Date.now() - lastFetchedAt.current) / 1000));
+    }, 1000);
+    return () => clearInterval(tickId);
+  }, []);
+
+  const repoFiltered = activeRepo ? tasks.filter(t => t.repo === activeRepo) : tasks;
+  const agoLabel = lastFetchedAt.current > 0
+    ? (secondsSince < 5 ? "just now" : `${secondsSince}s ago`)
+    : null;
+
+  return (
+    <div>
+      {agoLabel && (
+        <div className="flex justify-end mb-2">
+          <span className="text-[10px] text-[#444]">Updated {agoLabel}</span>
+        </div>
+      )}
+      <IssuesFilter tasks={repoFiltered} initialQuery={initialQuery} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- `app/api/issues/route.ts` — force-dynamic GET returning `getRecentTasks()` result
- `components/IssuesClient.tsx` — polls `/api/issues` every 30s; visibility pause/resume; "Updated Xs ago" counter; passes full tasks to `IssuesFilter`, applies repo filter client-side
- `app/issues/page.tsx` — passes all tasks as `initialTasks` to `IssuesClient`; stat cards still server-computed from initial fetch

## Test plan
- [ ] Issues page shows newly-closed issues within 30s without reload
- [ ] "Updated Xs ago" label appears after first poll
- [ ] Repo filter pills still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)