### PR TITLE
feat: record and display token count + cost per session (#146)

### DIFF
--- a/app/api/heartbeat/route.ts
+++ b/app/api/heartbeat/route.ts
@@ -15,7 +15,7 @@ export async function POST(req: Request) {
   }
 
   const body = await req.json();
-  const { agentType, status, task, project, issueNumber, issueRepo, startedAt: bodyStartedAt } = body as {
+  const { agentType, status, task, project, issueNumber, issueRepo, startedAt: bodyStartedAt, inputTokens, outputTokens, costUsd } = body as {
     agentType?: string;
     status?: string;
     task?: string;
@@ -23,6 +23,9 @@ export async function POST(req: Request) {
     issueNumber?: number;
     issueRepo?: string;
     startedAt?: string;
+    inputTokens?: number;
+    outputTokens?: number;
+    costUsd?: number;
   };
 
   if (!agentType || !status) {
@@ -51,6 +54,9 @@ export async function POST(req: Request) {
         durationMs,
         issueNumber: issueNumber ?? undefined,
         issueRepo: issueRepo ?? undefined,
+        inputTokens: inputTokens ?? undefined,
+        outputTokens: outputTokens ?? undefined,
+        costUsd: costUsd ?? undefined,
       }),
     ]);
     // Fire-and-forget — snapshot the current costs.json into Redis history

--- a/components/SessionHistory.tsx
+++ b/components/SessionHistory.tsx
@@ -133,11 +133,14 @@ export function SessionHistory() {
                       )}
                     </div>
 
-                    {r.durationMs > 0 && (
-                      <div className="flex-shrink-0 text-[10px] text-[#444] font-mono mt-0.5">
-                        {formatDuration(r.durationMs)}
-                      </div>
-                    )}
+                    <div className="flex-shrink-0 flex items-center gap-1.5 mt-0.5">
+                      {r.durationMs > 0 && (
+                        <span className="text-[10px] text-[#444] font-mono">{formatDuration(r.durationMs)}</span>
+                      )}
+                      {r.costUsd !== undefined && r.costUsd > 0 && (
+                        <span className="text-[10px] text-[#555] font-mono">${r.costUsd.toFixed(2)}</span>
+                      )}
+                    </div>
                   </div>
                 );
               })}

--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -158,6 +158,9 @@ export interface SessionHistoryRecord {
   durationMs: number;
   issueNumber?: number;
   issueRepo?: string;
+  inputTokens?: number;
+  outputTokens?: number;
+  costUsd?: number;
 }
 
 export async function pushSessionHistory(record: SessionHistoryRecord): Promise<void> {


### PR DESCRIPTION
## Summary
- `lib/redis.ts`: `inputTokens?`, `outputTokens?`, `costUsd?` on `SessionHistoryRecord`
- `app/api/heartbeat/route.ts`: destructure new fields from body, pass to `pushSessionHistory`
- `components/SessionHistory.tsx`: render `$X.XX` next to duration badge when `costUsd` present

## Test plan
- [ ] POST completed heartbeat with `costUsd: 0.04` → session row shows `$0.04`
- [ ] Sessions without costUsd: no change

🤖 Generated with [Claude Code](https://claude.com/claude-code)