### PR TITLE
feat: show localhost dev server URLs with live status

### DIFF
--- a/app/api/dev-servers/route.ts
+++ b/app/api/dev-servers/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+import { DEV_SERVERS } from "@/lib/dev-servers";
+
+export const dynamic = "force-dynamic";
+
+interface ServerStatus {
+  product: string;
+  port: number;
+  url: string;
+  alive: boolean;
+}
+
+async function checkPort(url: string): Promise<boolean> {
+  try {
+    await fetch(url, {
+      method: "HEAD",
+      signal: AbortSignal.timeout(1500),
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function GET() {
+  const results = await Promise.all(
+    DEV_SERVERS.map(async (s): Promise<ServerStatus> => {
+      const alive = await checkPort(s.url);
+      return { product: s.product, port: s.port, url: s.url, alive };
+    })
+  );
+
+  return NextResponse.json({ servers: results });
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,7 @@ import { QuotaCard } from "@/components/QuotaCard";
 import { LiveSessions } from "@/components/LiveSessions";
 import { RefreshIndicator } from "@/components/RefreshIndicator";
 import { CostChart } from "@/components/CostChart";
+import { DevServers } from "@/components/DevServers";
 import { getDecisions, getAgentActivity, getProductRepos, getDailyActivity } from "@/lib/local";
 import { getRecentTasks } from "@/lib/github";
 
@@ -80,6 +81,9 @@ export default async function Page() {
               subtitle={`${tasks.filter(t => t.status === "in-progress").length} in progress`}
             />
           </div>
+
+          {/* Dev Servers */}
+          <DevServers />
 
           {/* Activity Chart */}
           {dailyActivity.filter(d => d.count > 0).length >= 2 && (

--- a/components/DevServers.tsx
+++ b/components/DevServers.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Monitor } from "lucide-react";
+
+interface ServerStatus {
+  product: string;
+  port: number;
+  url: string;
+  alive: boolean;
+}
+
+export function DevServers() {
+  const [servers, setServers] = useState<ServerStatus[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  async function refresh() {
+    try {
+      const res = await fetch("/api/dev-servers", { cache: "no-store" });
+      const data = await res.json();
+      setServers(data.servers ?? []);
+    } catch {
+      // silent — leave previous state
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    refresh();
+    const id = setInterval(refresh, 30_000);
+    return () => clearInterval(id);
+  }, []);
+
+  const aliveCount = servers.filter(s => s.alive).length;
+
+  return (
+    <div className="rounded-xl border border-[#222] bg-[#161616] p-5">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <Monitor size={13} className="text-[#888]" />
+          <div className="text-[10px] uppercase tracking-widest text-[#888] font-medium">Dev Servers</div>
+        </div>
+        {!loading && (
+          <span className="text-[11px] text-[#555]">
+            {aliveCount} / {servers.length} up
+          </span>
+        )}
+      </div>
+
+      {loading ? (
+        <div className="space-y-2">
+          {[...Array(6)].map((_, i) => (
+            <div key={i} className="h-7 rounded bg-[#1e1e1e] animate-pulse" />
+          ))}
+        </div>
+      ) : (
+        <div className="space-y-0">
+          {servers.map(s => (
+            <div key={s.port} className="flex items-center justify-between py-2 border-b border-[#1e1e1e] last:border-0">
+              <div className="flex items-center gap-2.5 min-w-0">
+                {/* Status dot */}
+                <span className="relative flex h-2 w-2 shrink-0">
+                  {s.alive && (
+                    <span
+                      className="absolute inline-flex h-full w-full rounded-full opacity-50 animate-ping"
+                      style={{ background: "#22c55e" }}
+                    />
+                  )}
+                  <span
+                    className="relative inline-flex h-2 w-2 rounded-full"
+                    style={{ background: s.alive ? "#22c55e" : "#333" }}
+                  />
+                </span>
+                {/* Product name */}
+                <span className="text-xs text-[#999] truncate">{s.product}</span>
+              </div>
+
+              {/* URL link + port */}
+              <a
+                href={s.url}
+                target="_blank"
+                rel="noreferrer"
+                className="flex items-center gap-1.5 text-[11px] font-mono shrink-0 ml-4 transition-colors"
+                style={{ color: s.alive ? "#6b9cf6" : "#444" }}
+                title={`Open ${s.url}`}
+              >
+                <span>:{s.port}</span>
+              </a>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/dev-servers.ts
+++ b/lib/dev-servers.ts
@@ -1,0 +1,14 @@
+export interface DevServer {
+  product: string;
+  port: number;
+  url: string;
+}
+
+export const DEV_SERVERS: DevServer[] = [
+  { product: "Whitebox",      port: 3000, url: "http://localhost:3000" },
+  { product: "FormPilot",     port: 3300, url: "http://localhost:3300" },
+  { product: "AgentScore",    port: 3500, url: "http://localhost:3500" },
+  { product: "Money Flow",    port: 3100, url: "http://localhost:3100" },
+  { product: "Health Credit", port: 3200, url: "http://localhost:3200" },
+  { product: "Gym Form Coach",port: 8081, url: "http://localhost:8081" },
+];


### PR DESCRIPTION
## What
- Added `lib/dev-servers.ts` — config file with port mappings for all 6 products
- Added `app/api/dev-servers/route.ts` — server-side API that checks each port with a 1.5s timeout via `AbortSignal.timeout`
- Added `components/DevServers.tsx` — client component that polls `/api/dev-servers` every 30s, shows each product with a green (alive) or grey (down) status dot and clickable `localhost:PORT` link
- Added `DevServers` to the main dashboard page between the metric cards and the activity chart

## Why
Closes #157

## Acceptance Criteria
- [x] Each product row shows its localhost URL as a clickable link
- [x] Port mapping is stored in a config (`lib/dev-servers.ts`), not hardcoded in UI
- [x] Live status indicator: green dot + ping animation if port is responding, grey if not
- [x] Polls every 30s — stays current while the dashboard is open

## Test Plan
1. `npm run dev` in whitebox repo
2. Open http://localhost:3000 — Dev Servers panel is visible on the dashboard
3. `/api/dev-servers` returns `{ servers: [...] }` with `alive: true/false` per port
4. Start any other product's dev server (e.g. `cd money-flow-frontend && npm start`) — within 30s the dot turns green

@qa-agent please review